### PR TITLE
Add rcExtensions option; closes #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Add `rcExtensions` option.
+
 ## 1.0.2
 
 - Fix handling of `require()`'s within JS module configs.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ cosmiconfig continues to search in these places all the way down the file tree u
 
 Additionally, all of these search locations are configurable: you can customize filenames or turn off any location.
 
+You can also look for rc files with extensions, e.g. `.soursocksrc.json` or `.soursocksrc.yaml`.
+You may like extensions on your rc files because you'll get syntax highlighting and linting in text editors.
+
 ## Installation
 
 ```
@@ -94,6 +97,10 @@ Name of the "rc file" to look for, which can be formatted as JSON or YAML.
 
 If `false`, cosmiconfig will not look for an rc file.
 
+If `rcExtensions: true`, the rc file can also have extensions that specify the syntax, e.g. `.[moduleName]rc.json`.
+You may like extensions on your rc files because you'll get syntax highlighting and linting in text editors.
+Also, with `rcExtensions: true`, you can use JS modules as rc files, e.g. `.[moduleName]rc.js`.
+
 ##### js
 
 Type: `string` or `false`
@@ -132,6 +139,21 @@ If `true`, cosmiconfig will expect rc files to be strict JSON. No YAML permitted
 By default, rc files are parsed with [js-yaml](https://github.com/nodeca/js-yaml), which is
 more permissive with punctuation than standard strict JSON.
 
+##### rcExtensions
+
+Type: `boolean`
+Default: `false`
+
+If `true`, cosmiconfig will look for rc files with extensions, in addition to rc files without.
+
+This adds a few steps to the search process.
+Instead of *just* looking for `.goldengrahamsrc` (no extension), it will also look for the following, in this order:
+
+- `.goldengrahamsrc.json`
+- `.goldengrahamsrc.yaml`
+- `.goldengrahamsrc.yml`
+- `.goldengrahamsrc.js`
+
 ##### cwd
 
 Type: `string`
@@ -150,7 +172,7 @@ Directory where the search will stop.
 
 [rc](https://github.com/dominictarr/rc) serves its focused purpose well. cosmiconfig differs in a few key ways — making it more useful for some projects, less useful for others:
 
-- Looks for configuration in some different places: in a `package.json` property, an rc file, and a `.config.js` file.
+- Looks for configuration in some different places: in a `package.json` property, an rc file, a `.config.js` file, and rc files with extensions.
 - Built-in support for JSON, YAML, and CommonJS formats.
 - Stops at the first configuration found, instead of finding all that can be found down the filetree and merging them automatically.
 - Options.

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = function(moduleName, options) {
       if (result || !options.rc) return result;
       return loadRc(path.join(currentSearchPath, options.rc), {
         strictJson: options.rcStrictJson,
+        extensions: options.rcExtensions,
       });
     }).then(function(result) {
       if (result || !options.js) return result;

--- a/lib/loadRc.js
+++ b/lib/loadRc.js
@@ -4,28 +4,89 @@ var fs = require('graceful-fs');
 var Promise = require('pinkie-promise');
 var yaml = require('js-yaml');
 var parseJson = require('parse-json');
+var requireFromString = require('require-from-string');
 
 module.exports = function(filepath, options) {
-  return new Promise(function(resolve, reject) {
-    fs.readFile(filepath, 'utf8', function(fileError, content) {
-      if (fileError) {
-        if (fileError.code === 'ENOENT') return resolve(null);
-        return reject(fileError);
-      }
-      resolve(content);
-    });
-  }).then(function(content) {
-    if (!content) return null;
-
-    var parsedConfig = (options.strictJson)
-      ? parseJson(content, filepath)
-      : yaml.safeLoad(content, {
-        filename: filepath,
-      });
-
-    return {
-      config: parsedConfig,
-      filepath: filepath,
-    };
+  return loadExtensionlessRc().then(function(result) {
+    if (result) return result;
+    if (options.extensions) return loadRcWithExtensions();
+    return null;
   });
+
+  function loadExtensionlessRc() {
+    return readRcFile().then(function(content) {
+      if (!content) return null;
+
+      var pasedConfig = (options.strictJson)
+        ? parseJson(content, filepath)
+        : yaml.safeLoad(content, {
+          filename: filepath,
+        });
+      return {
+        config: pasedConfig,
+        filepath: filepath,
+      };
+    });
+  }
+
+  function loadRcWithExtensions() {
+    return readRcFile('json').then(function(content) {
+      if (content) {
+        var successFilepath = filepath + '.json';
+        return {
+          config: parseJson(content, successFilepath),
+          filepath: successFilepath,
+        };
+      }
+      // If not content was found in the file with extension,
+      // try the next possible extension
+      return readRcFile('yaml');
+    }).then(function(content) {
+      if (content) {
+        // If the previous check returned an object with a config
+        // property, then it succeeded and this step can be skipped
+        if (content.config) return content;
+        // If it just returned a string, then *this* check succeeded
+        var successFilepath = filepath + '.yaml';
+        return {
+          config: yaml.safeLoad(content, { filename: successFilepath }),
+          filepath: successFilepath,
+        };
+      }
+      return readRcFile('yml');
+    }).then(function(content) {
+      if (content) {
+        if (content.config) return content;
+        var successFilepath = filepath + '.yml';
+        return {
+          config: yaml.safeLoad(content, { filename: successFilepath }),
+          filepath: successFilepath,
+        };
+      }
+      return readRcFile('js');
+    }).then(function(content) {
+      if (content) {
+        if (content.config) return content;
+        var successFilepath = filepath + '.js';
+        return {
+          config: requireFromString(content, successFilepath),
+          filepath: successFilepath,
+        };
+      }
+      return null;
+    });
+  }
+
+  function readRcFile(extension) {
+    return new Promise(function(resolve, reject) {
+      var filepathWithExtension = (extension) ? filepath + '.' + extension : filepath;
+      fs.readFile(filepathWithExtension, 'utf8', function(fileError, content) {
+        if (fileError) {
+          if (fileError.code === 'ENOENT') return resolve(null);
+          return reject(fileError);
+        }
+        resolve(content);
+      });
+    });
+  }
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "ava": "0.9.1",
     "eslint": "1.10.3",
+    "lodash": "3.10.1",
     "sinon": "1.17.2"
   }
 }

--- a/test/failed-searches.js
+++ b/test/failed-searches.js
@@ -2,6 +2,7 @@ var test = require('ava');
 var sinon = require('sinon');
 var path = require('path');
 var fs = require('graceful-fs');
+var _ = require('lodash');
 var cosmiconfig = require('..');
 
 function absolutePath(str) {
@@ -33,23 +34,23 @@ test.serial('do not find file, and give up', function(t) {
     stopDir: absolutePath('.'),
   }).then(function(result) {
     t.is(readFileStub.callCount, 9);
-    t.is(readFileStub.getCall(0).args[0], absolutePath('a/b/package.json'),
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/package.json'),
       'first dir: a/b/package.json');
-    t.is(readFileStub.getCall(1).args[0], absolutePath('a/b/.foorc'),
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/.foorc'),
       'first dir: a/b/.foorc');
-    t.is(readFileStub.getCall(2).args[0], absolutePath('a/b/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/foo.config.js'),
       'first dir: a/b/foo.config.js');
-    t.is(readFileStub.getCall(3).args[0], absolutePath('a/package.json'),
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/package.json'),
       'second dir: a/package.json');
-    t.is(readFileStub.getCall(4).args[0], absolutePath('a/.foorc'),
+    t.is(_.get(readFileStub.getCall(4), 'args[0]'), absolutePath('a/.foorc'),
       'second dir: a/.foorc');
-    t.is(readFileStub.getCall(5).args[0], absolutePath('a/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(5), 'args[0]'), absolutePath('a/foo.config.js'),
       'second dir: a/foo.config.js');
-    t.is(readFileStub.getCall(6).args[0], absolutePath('/package.json'),
+    t.is(_.get(readFileStub.getCall(6), 'args[0]'), absolutePath('/package.json'),
       'third and last dir: /package.json');
-    t.is(readFileStub.getCall(7).args[0], absolutePath('/.foorc'),
+    t.is(_.get(readFileStub.getCall(7), 'args[0]'), absolutePath('/.foorc'),
       'third and last dir: /.foorc');
-    t.is(readFileStub.getCall(8).args[0], absolutePath('/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(8), 'args[0]'), absolutePath('/foo.config.js'),
       'third and last dir: /foo.config.js');
     t.is(result, null);
     readFileStub.restore();
@@ -81,17 +82,17 @@ test.serial('stop at stopDir, and give up', function(t) {
     stopDir: absolutePath('a'),
   }).then(function(result) {
     t.is(readFileStub.callCount, 6);
-    t.is(readFileStub.getCall(0).args[0], absolutePath('a/b/package.json'),
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/package.json'),
       'first dir: a/b/package.json');
-    t.is(readFileStub.getCall(1).args[0], absolutePath('a/b/.foorc'),
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/.foorc'),
       'first dir: a/b/.foorc');
-    t.is(readFileStub.getCall(2).args[0], absolutePath('a/b/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/foo.config.js'),
       'first dir: a/b/foo.config.js');
-    t.is(readFileStub.getCall(3).args[0], absolutePath('a/package.json'),
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/package.json'),
       'second and stopDir: a/package.json');
-    t.is(readFileStub.getCall(4).args[0], absolutePath('a/.foorc'),
+    t.is(_.get(readFileStub.getCall(4), 'args[0]'), absolutePath('a/.foorc'),
       'second and stopDir: a/.foorc');
-    t.is(readFileStub.getCall(5).args[0], absolutePath('a/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(5), 'args[0]'), absolutePath('a/foo.config.js'),
       'second and stopDir: a/foo.config.js');
     t.is(result, null);
     readFileStub.restore();
@@ -191,6 +192,122 @@ test.serial('find invalid JS in .config.js file', function(t) {
   return cosmiconfig('foo', {
     cwd: startDir,
     stopDir: absolutePath('a'),
+  }).catch(function(error) {
+    t.ok(error, 'threw error');
+    t.is(error.name, 'SyntaxError', 'threw correct error type');
+    readFileStub.restore();
+  });
+});
+
+// RC file with specified extension
+
+test.serial('with rcExtensions, find invalid JSON in .foorc.json', function(t) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  var readFileStub = sinon.stub(fs, 'readFile', function(searchPath, encoding, callback) {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+        callback({ code: 'ENOENT' });
+        break;
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+        callback(null, '{ "found": true,, }');
+        break;
+      default:
+        callback(new Error('irrelevant path ' + searchPath));
+    }
+  });
+
+  return cosmiconfig('foo', {
+    cwd: startDir,
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).catch(function(error) {
+    t.ok(error, 'threw error');
+    t.is(error.name, 'JSONError', 'threw correct error type');
+    readFileStub.restore();
+  });
+});
+
+test.serial('with rcExtensions, find invalid YAML in .foorc.yaml', function(t) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  var readFileStub = sinon.stub(fs, 'readFile', function(searchPath, encoding, callback) {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+        callback({ code: 'ENOENT' });
+        break;
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+        callback(null, 'found: thing: true');
+        break;
+      default:
+        callback(new Error('irrelevant path ' + searchPath));
+    }
+  });
+
+  return cosmiconfig('foo', {
+    cwd: startDir,
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).catch(function(error) {
+    t.ok(error, 'threw error');
+    t.is(error.name, 'YAMLException', 'threw correct error type');
+    readFileStub.restore();
+  });
+});
+
+test.serial('with rcExtensions, find invalid YAML in .foorc.yml', function(t) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  var readFileStub = sinon.stub(fs, 'readFile', function(searchPath, encoding, callback) {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+        callback({ code: 'ENOENT' });
+        break;
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+        callback(null, 'found: thing: true');
+        break;
+      default:
+        callback(new Error('irrelevant path ' + searchPath));
+    }
+  });
+
+  return cosmiconfig('foo', {
+    cwd: startDir,
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).catch(function(error) {
+    t.ok(error, 'threw error');
+    t.is(error.name, 'YAMLException', 'threw correct error type');
+    readFileStub.restore();
+  });
+});
+
+test.serial('with rcExtensions, find invalid JS in .foorc.js', function(t) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  var readFileStub = sinon.stub(fs, 'readFile', function(searchPath, encoding, callback) {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+        callback({ code: 'ENOENT' });
+        break;
+      case absolutePath('a/b/c/d/e/f/.foorc.js'):
+        callback(null, 'module.exports ==! { found: true };');
+        break;
+      default:
+        callback(new Error('irrelevant path ' + searchPath));
+    }
+  });
+
+  return cosmiconfig('foo', {
+    cwd: startDir,
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
   }).catch(function(error) {
     t.ok(error, 'threw error');
     t.is(error.name, 'SyntaxError', 'threw correct error type');

--- a/test/successful-searches.js
+++ b/test/successful-searches.js
@@ -2,6 +2,7 @@ var test = require('ava');
 var sinon = require('sinon');
 var path = require('path');
 var fs = require('graceful-fs');
+var _ = require('lodash');
 var cosmiconfig = require('..');
 
 function absolutePath(str) {
@@ -36,21 +37,21 @@ test.serial('find rc file in third searched dir, with a package.json lacking pro
     stopDir: absolutePath('.') ,
   }).then(function(result) {
     t.is(readFileStub.callCount, 8);
-    t.is(readFileStub.getCall(0).args[0], absolutePath('a/b/c/d/e/f/package.json'),
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/package.json'),
       'first dir: checked /a/b/c/d/e/f/package.json');
-    t.is(readFileStub.getCall(1).args[0], absolutePath('a/b/c/d/e/f/.foorc'),
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc'),
       'first dir: checked /a/b/c/d/e/f/.foorc');
-    t.is(readFileStub.getCall(2).args[0], absolutePath('a/b/c/d/e/f/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/c/d/e/f/foo.config.js'),
       'first dir: checked /a/b/c/d/e/f/foo.config.js');
-    t.is(readFileStub.getCall(3).args[0], absolutePath('a/b/c/d/e/package.json'),
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/b/c/d/e/package.json'),
       'second dir: checked /a/b/c/d/e/package.json');
-    t.is(readFileStub.getCall(4).args[0], absolutePath('a/b/c/d/e/.foorc'),
+    t.is(_.get(readFileStub.getCall(4), 'args[0]'), absolutePath('a/b/c/d/e/.foorc'),
       'second dir: checked /a/b/c/d/e/.foorc');
-    t.is(readFileStub.getCall(5).args[0], absolutePath('a/b/c/d/e/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(5), 'args[0]'), absolutePath('a/b/c/d/e/foo.config.js'),
       'second dir: checked /a/b/c/d/e/foo.config.js');
-    t.is(readFileStub.getCall(6).args[0], absolutePath('a/b/c/d/package.json'),
+    t.is(_.get(readFileStub.getCall(6), 'args[0]'), absolutePath('a/b/c/d/package.json'),
       'third dir: checked /a/b/c/d/package.json');
-    t.is(readFileStub.getCall(7).args[0], absolutePath('a/b/c/d/.foorc'),
+    t.is(_.get(readFileStub.getCall(7), 'args[0]'), absolutePath('a/b/c/d/.foorc'),
       'third dir: checked /a/b/c/d/.foorc');
     t.same(result.config, {
       found: true,
@@ -84,13 +85,13 @@ test.serial('find package.json prop in second searched dir', function(t) {
     stopDir: absolutePath('.') ,
   }).then(function(result) {
     t.is(readFileStub.callCount, 4);
-    t.is(readFileStub.getCall(0).args[0], absolutePath('a/b/c/d/e/f/package.json'),
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/package.json'),
       'first dir: checked /a/b/c/d/e/f/package.json');
-    t.is(readFileStub.getCall(1).args[0], absolutePath('a/b/c/d/e/f/.foorc'),
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc'),
       'first dir: checked /a/b/c/d/e/f/.foorc');
-    t.is(readFileStub.getCall(2).args[0], absolutePath('a/b/c/d/e/f/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/c/d/e/f/foo.config.js'),
       'first dir: checked /a/b/c/d/e/f/foo.config.js');
-    t.is(readFileStub.getCall(3).args[0], absolutePath('a/b/c/d/e/package.json'),
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/b/c/d/e/package.json'),
       'second dir: checked /a/b/c/d/e/package.json');
     t.same(result.config, {
       found: true,
@@ -124,11 +125,11 @@ test.serial('find JS file in first searched dir', function(t) {
     stopDir: absolutePath('.'),
   }).then(function(result) {
     t.is(readFileStub.callCount, 3);
-    t.is(readFileStub.getCall(0).args[0], absolutePath('a/b/c/d/e/f/package.json'),
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/package.json'),
       'first dir: checked /a/b/c/d/e/f/package.json');
-    t.is(readFileStub.getCall(1).args[0], absolutePath('a/b/c/d/e/f/.foorc'),
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc'),
       'first dir: checked /a/b/c/d/e/f/.foorc');
-    t.is(readFileStub.getCall(2).args[0], absolutePath('a/b/c/d/e/f/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/c/d/e/f/foo.config.js'),
       'first dir: checked /a/b/c/d/e/f/foo.config.js');
     t.same(result.config, {
       found: true,
@@ -163,13 +164,13 @@ test.serial('find package.json in second directory searched, with alternate name
     stopDir: absolutePath('.'),
   }).then(function(result) {
     t.is(readFileStub.callCount, 4);
-    t.is(readFileStub.getCall(0).args[0], absolutePath('a/b/c/d/e/f/package.json'),
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/package.json'),
       'first dir: checked /a/b/c/d/e/f/package.json');
-    t.is(readFileStub.getCall(1).args[0], absolutePath('a/b/c/d/e/f/.wowza'),
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/f/.wowza'),
       'first dir: checked /a/b/c/d/e/f/.wowza');
-    t.is(readFileStub.getCall(2).args[0], absolutePath('a/b/c/d/e/f/wowzaConfig.js'),
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/c/d/e/f/wowzaConfig.js'),
       'first dir: checked /a/b/c/d/e/f/wowzaConfig.js');
-    t.is(readFileStub.getCall(3).args[0], absolutePath('a/b/c/d/e/package.json'),
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/b/c/d/e/package.json'),
       'first dir: checked /a/b/c/d/e/package.json');
     t.same(result.config, {
       found: true,
@@ -207,15 +208,15 @@ test.serial('find rc file in third searched dir, skipping packageProp, with rcSt
     rcStrictJson: true,
   }).then(function(result) {
     t.is(readFileStub.callCount, 5);
-    t.is(readFileStub.getCall(0).args[0], absolutePath('a/b/c/d/e/f/.foorc'),
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc'),
       'first dir: checked /a/b/c/d/e/f/.foorc');
-    t.is(readFileStub.getCall(1).args[0], absolutePath('a/b/c/d/e/f/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/f/foo.config.js'),
       'first dir: checked /a/b/c/d/e/f/foo.config.js');
-    t.is(readFileStub.getCall(2).args[0], absolutePath('a/b/c/d/e/.foorc'),
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/c/d/e/.foorc'),
       'second dir: checked /a/b/c/d/e/.foorc');
-    t.is(readFileStub.getCall(3).args[0], absolutePath('a/b/c/d/e/foo.config.js'),
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/b/c/d/e/foo.config.js'),
       'second dir: checked /a/b/c/d/e/foo.config.js');
-    t.is(readFileStub.getCall(4).args[0], absolutePath('a/b/c/d/.foorc'),
+    t.is(_.get(readFileStub.getCall(4), 'args[0]'), absolutePath('a/b/c/d/.foorc'),
       'third dir: checked /a/b/c/d/.foorc');
     t.same(result.config, {
       found: true,
@@ -251,14 +252,203 @@ test.serial('find package.json prop in second searched dir, skipping js and rc',
     rc: false,
   }).then(function(result) {
     t.is(readFileStub.callCount, 2);
-    t.is(readFileStub.getCall(0).args[0], absolutePath('a/b/c/d/e/f/package.json'),
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/package.json'),
       'first dir: checked /a/b/c/d/e/f/package.json');
-    t.is(readFileStub.getCall(1).args[0], absolutePath('a/b/c/d/e/package.json'),
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/package.json'),
       'second dir: checked /a/b/c/d/e/package.json');
     t.same(result.config, {
       found: true,
     });
     t.is(result.filepath, absolutePath('a/b/c/d/e/package.json'));
+    readFileStub.restore();
+  });
+});
+
+// RC file with specified extension
+
+test.serial('with rcExtensions, find .foorc.json in second searched dir', function(t) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  var readFileStub = sinon.stub(fs, 'readFile', function(searchPath, encoding, callback) {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.js'):
+      case absolutePath('a/b/c/d/e/f/foo.config.js'):
+      case absolutePath('a/b/c/d/e/package.json'):
+      case absolutePath('a/b/c/d/e/.foorc'):
+        callback({ code: 'ENOENT' });
+        break;
+      case absolutePath('a/b/c/d/e/.foorc.json'):
+        callback(null, '{ "found": true }');
+        break;
+      default:
+        callback(new Error('irrelevant path ' + searchPath));
+    }
+  });
+
+  return cosmiconfig('foo', {
+    cwd: startDir,
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).then(function(result) {
+    t.is(readFileStub.callCount, 10);
+
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/package.json'),
+      'first dir: checked a/b/c/d/e/f/package.json');
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc'),
+      'first dir: checked a/b/c/d/e/f/.foorc');
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.json'),
+      'first dir: checked a/b/c/d/e/f/.foorc.json');
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.yaml'),
+      'first dir: checked a/b/c/d/e/f/.foorc.yaml');
+    t.is(_.get(readFileStub.getCall(4), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.yml'),
+      'first dir: checked a/b/c/d/e/f/.foorc.yml');
+    t.is(_.get(readFileStub.getCall(5), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.js'),
+      'first dir: checked a/b/c/d/e/f/.foorc.js');
+    t.is(_.get(readFileStub.getCall(6), 'args[0]'), absolutePath('a/b/c/d/e/f/foo.config.js'),
+      'first dir: checked a/b/c/d/e/f/foo.config.js');
+    t.is(_.get(readFileStub.getCall(7), 'args[0]'), absolutePath('a/b/c/d/e/package.json'),
+      'first dir: checked a/b/c/d/e/package.json');
+    t.is(_.get(readFileStub.getCall(8), 'args[0]'), absolutePath('a/b/c/d/e/.foorc'),
+      'first dir: checked a/b/c/d/e/.foorc');
+    t.is(_.get(readFileStub.getCall(9), 'args[0]'), absolutePath('a/b/c/d/e/.foorc.json'),
+      'first dir: checked a/b/c/d/e/.foorc.json');
+    t.same(result.config, {
+      found: true,
+    });
+    t.is(result.filepath, absolutePath('a/b/c/d/e/.foorc.json'));
+    readFileStub.restore();
+  });
+});
+
+test.serial('with rcExtensions, find .foorc.yaml in first searched dir', function(t) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  var readFileStub = sinon.stub(fs, 'readFile', function(searchPath, encoding, callback) {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+        callback({ code: 'ENOENT' });
+        break;
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+        callback(null, 'found: true');
+        break;
+      default:
+        callback(new Error('irrelevant path ' + searchPath));
+    }
+  });
+
+  return cosmiconfig('foo', {
+    cwd: startDir,
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).then(function(result) {
+    t.is(readFileStub.callCount, 4);
+
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/package.json'),
+      'first dir: checked a/b/c/d/e/f/package.json');
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc'),
+      'first dir: checked a/b/c/d/e/f/.foorc');
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.json'),
+      'first dir: checked a/b/c/d/e/f/.foorc.json');
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.yaml'),
+      'first dir: checked a/b/c/d/e/f/.foorc.yaml');
+    t.same(result.config, {
+      found: true,
+    });
+    t.is(result.filepath, absolutePath('a/b/c/d/e/f/.foorc.yaml'));
+    readFileStub.restore();
+  });
+});
+
+test.serial('with rcExtensions, find .foorc.yml in first searched dir', function(t) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  var readFileStub = sinon.stub(fs, 'readFile', function(searchPath, encoding, callback) {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+        callback({ code: 'ENOENT' });
+        break;
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+        callback(null, 'found: true');
+        break;
+      default:
+        callback(new Error('irrelevant path ' + searchPath));
+    }
+  });
+
+  return cosmiconfig('foo', {
+    cwd: startDir,
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).then(function(result) {
+    t.is(readFileStub.callCount, 5);
+
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/package.json'),
+      'first dir: checked a/b/c/d/e/f/package.json');
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc'),
+      'first dir: checked a/b/c/d/e/f/.foorc');
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.json'),
+      'first dir: checked a/b/c/d/e/f/.foorc.json');
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.yaml'),
+      'first dir: checked a/b/c/d/e/f/.foorc.yaml');
+    t.is(_.get(readFileStub.getCall(4), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.yml'),
+      'first dir: checked a/b/c/d/e/f/.foorc.yml');
+    t.same(result.config, {
+      found: true,
+    });
+    t.is(result.filepath, absolutePath('a/b/c/d/e/f/.foorc.yml'));
+    readFileStub.restore();
+  });
+});
+
+test.serial('with rcExtensions, find .foorc.js in first searched dir', function(t) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  var readFileStub = sinon.stub(fs, 'readFile', function(searchPath, encoding, callback) {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+        callback({ code: 'ENOENT' });
+        break;
+      case absolutePath('a/b/c/d/e/f/.foorc.js'):
+        callback(null, 'module.exports = { found: true };');
+        break;
+      default:
+        callback(new Error('irrelevant path ' + searchPath));
+    }
+  });
+
+  return cosmiconfig('foo', {
+    cwd: startDir,
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).then(function(result) {
+    t.is(readFileStub.callCount, 6);
+
+    t.is(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/c/d/e/f/package.json'),
+      'first dir: checked a/b/c/d/e/f/package.json');
+    t.is(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc'),
+      'first dir: checked a/b/c/d/e/f/.foorc');
+    t.is(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.json'),
+      'first dir: checked a/b/c/d/e/f/.foorc.json');
+    t.is(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.yaml'),
+      'first dir: checked a/b/c/d/e/f/.foorc.yaml');
+    t.is(_.get(readFileStub.getCall(4), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.yml'),
+      'first dir: checked a/b/c/d/e/f/.foorc.yml');
+    t.is(_.get(readFileStub.getCall(5), 'args[0]'), absolutePath('a/b/c/d/e/f/.foorc.js'),
+      'first dir: checked a/b/c/d/e/f/.foorc.js');
+    t.same(result.config, {
+      found: true,
+    });
+    t.is(result.filepath, absolutePath('a/b/c/d/e/f/.foorc.js'));
     readFileStub.restore();
   });
 });


### PR DESCRIPTION
This adds an `rcExtensions` option, which causes cosmiconfig to look for rc files with the following extensions (in order): `json`, `yaml`, `yml`, `js`.

(Should we cut `yml`?)

One change I made that is not relevant to this particular functionality is to use `_.get()` in some tests, because I found I could get more helpful error messages that way, sometimes.