### PR TITLE
Prevent cosmiconfig from immediately monkey patching `fs`

### DIFF
--- a/lib/loadDefinedFile.js
+++ b/lib/loadDefinedFile.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var fs = require('graceful-fs');
 var Promise = require('pinkie-promise');
 var yaml = require('js-yaml');
 var parseJson = require('parse-json');
 var requireFromString = require('require-from-string');
 
 module.exports = function(filepath, expectedFormat) {
+  var fs = require('graceful-fs');
   return new Promise(function(resolve, reject) {
     fs.readFile(filepath, 'utf8', function(fileError, content) {
       if (fileError) return reject(fileError);

--- a/lib/loadJs.js
+++ b/lib/loadJs.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var fs = require('graceful-fs');
 var Promise = require('pinkie-promise');
 var requireFromString = require('require-from-string');
 
 module.exports = function(filepath) {
+  var fs = require('graceful-fs');
   return new Promise(function(resolve, reject) {
     fs.readFile(filepath, 'utf8', function(fileError, content) {
       if (fileError) {

--- a/lib/loadPackageProp.js
+++ b/lib/loadPackageProp.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var path = require('path');
-var fs = require('graceful-fs');
 var Promise = require('pinkie-promise');
 var parseJson = require('parse-json');
 
 module.exports = function(packageDir, packageProp) {
+  var fs = require('graceful-fs');
   var packagePath = path.join(packageDir, 'package.json');
   return new Promise(function(resolve, reject) {
     fs.readFile(packagePath, 'utf8', function(fileError, content) {

--- a/lib/loadRc.js
+++ b/lib/loadRc.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var fs = require('graceful-fs');
 var Promise = require('pinkie-promise');
 var yaml = require('js-yaml');
 var parseJson = require('parse-json');
 var requireFromString = require('require-from-string');
 
 module.exports = function(filepath, options) {
+  var fs = require('graceful-fs');
   return loadExtensionlessRc().then(function(result) {
     if (result) return result;
     if (options.extensions) return loadRcWithExtensions();


### PR DESCRIPTION
Prevent cosmiconfig from immediately monkey patching `fs`

This allows cosmiconfig to be imported in environments that don't have access to the `fs` module. It does not make it possible to run cosmiconfig in these environments.

When required, the `graceful-fs` module attempts to immediately monkey patch node's `fs` module. This (understandably) causes errors if running in an environment without an `fs` module.

This change means that `graceful-fs` will not run until cosmiconfig is invoked, instead of when cosmiconfig is required or imported by another module.

This should help with https://github.com/stylelint/stylelint/issues/993