### PR TITLE
Fix error if searchPath doesn't exist in file system

### DIFF
--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -48,6 +48,14 @@ module.exports = function (options) {
           ? absoluteSearchPath
           : path.dirname(absoluteSearchPath);
         return searchDirectory(directory);
+      }, (error) => {
+        if (error.code === 'ENOENT') {
+          // When search path doesn't exist, the path may be a virtual path.
+          // e.g.) Compiled CSS path, S3 URL
+          return null;
+        } else {
+          throw error;
+        }
       });
   }
 

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -337,3 +337,13 @@ test.serial('Configuration file not exist', (assert) => {
     assert.is(result, null);
   });
 });
+
+test.serial('searchPath file not exist', (assert) => {
+  // To fail isDirectory() function.
+  if (statStub.restore) statStub.restore();
+
+  const loadConfig = cosmiconfig('not_exist_search_path').load;
+  return loadConfig('foo/bar/foo/bar').then((result) => {
+    assert.is(result, null);
+  });
+});


### PR DESCRIPTION
Problem
------

In our environment, cosmiconfig crashes.

We use cosmiconfig in StyleLint, and StyleLint is for compiled CSS from Less.

In the case, searchPath may become a virtual path.
Then, cosmiconfig crashes.

For example

```javascript
// gulpfile.js
var gulp = require('gulp');
var less = require('gulp-less');
var path = require('path');
var stylelint = require('gulp-stylelint');

gulp.task('less', function () {
  return gulp.src('*.less')
    .pipe(less({}))
    .pipe(stylelint({
      reporters: [{formatter: 'string', console: true}],
    }))
    .pipe(gulp.dest('./'));
});
```

```sh
$ ls
gulpfile.js
node_modules/
test.less

$ gulp less
[18:07:23] Using gulpfile /private/var/folders/3r/fls_qvbs5_31jdfpq2gqnbt0g1tg5_/T/tmp.EEBVXvorJc/gulpfile.js
[18:07:23] Starting 'less'...

events.js:160
      throw er; // Unhandled 'error' event
      ^
Error: ENOENT: no such file or directory, stat '/private/var/folders/3r/fls_qvbs5_31jdfpq2gqnbt0g1tg5_/T/tmp.EEBVXvorJc/test.css'
    at Error (native)
```

Solution
-------

I've added an error handler for `isDirectory()` function in `load()`.
If target of `isDirectory()` doesn't exist, `load` method returns null.
Then, cosmiconfig doesn't crash with virtual path.