### PR TITLE
Add Node 0.12 support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,11 @@
 {
   "extends": [
     "eslint-config-davidtheclark-node"
-  ]
+  ],
+  "rules": {
+    "no-var": "off",
+    "prefer-const": "off",
+    "prefer-arrow-callback": "off",
+    "node/no-unsupported-features": ["error", {"version": 0.12}],
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - "0.12"
   - "4"
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
-matrix:
-  include:
-  - node_js: '0.12'
-    script: 'npm run ava'
-  - node_js: '4'
-  - node_js: '6'
+node_js:
+  - "0.12"
+  - "4"
+  - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-node_js:
-  - "0.12"
-  - "4"
-  - "6"
+matrix:
+  include:
+  - node_js: '0.12'
+    script: 'npm run ava'
+  - node_js: '4'
+  - node_js: '6'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: Node 0.12 support.
+
 ## 2.0.2
 
 - Fixed: Node version specified in `package.json`.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Tested in Node 4+.
 ## Usage
 
 ```js
-const cosmiconfig = require('cosmiconfig');
+var cosmiconfig = require('cosmiconfig');
 
-const explorer = cosmiconfig(yourModuleName[, options]);
+var explorer = cosmiconfig(yourModuleName[, options]);
 
 explorer.load(yourSearchPath)
   .then((result) => {
@@ -49,7 +49,7 @@ explorer.load(yourSearchPath)
 The function `cosmiconfig()` searches for a configuration object and returns a Promise,
 which resolves with an object containing the information you're looking for.
 
-So let's say `const yourModuleName = 'goldengrahams'` — here's how cosmiconfig will work:
+So let's say `var yourModuleName = 'goldengrahams'` — here's how cosmiconfig will work:
 
 - Starting from `process.cwd()` (or some other directory defined by the `searchPath` argument to `load()`), it looks for configuration objects in three places, in this order:
   1. A `goldengrahams` property in a `package.json` file (or some other property defined by `options.packageProp`);
@@ -75,7 +75,7 @@ To avoid or work around caching, you can
 
 ## API
 
-### `const explorer = cosmiconfig(moduleName[, options])`
+### `var explorer = cosmiconfig(moduleName[, options])`
 
 Creates a cosmiconfig instance (i.e. explorer) configured according to the arguments, and initializes its caches.
 

--- a/index.js
+++ b/index.js
@@ -1,17 +1,18 @@
 'use strict';
 
-const path = require('path');
-const oshomedir = require('os-homedir');
-const minimist = require('minimist');
-const createExplorer = require('./lib/createExplorer');
+var path = require('path');
+var oshomedir = require('os-homedir');
+var minimist = require('minimist');
+var assign = require('object-assign');
+var createExplorer = require('./lib/createExplorer');
 
-const parsedCliArgs = minimist(process.argv);
+var parsedCliArgs = minimist(process.argv);
 
 module.exports = function (moduleName, options) {
-  options = Object.assign({
+  options = assign({
     packageProp: moduleName,
-    rc: `.${moduleName}rc`,
-    js: `${moduleName}.config.js`,
+    rc: '.' + moduleName + 'rc',
+    js: moduleName + '.config.js',
     argv: 'config',
     rcStrictJson: false,
     stopDir: oshomedir(),

--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -1,17 +1,17 @@
 'use strict';
 
-const path = require('path');
-const fs = require('graceful-fs');
-const loadPackageProp = require('./loadPackageProp');
-const loadRc = require('./loadRc');
-const loadJs = require('./loadJs');
-const loadDefinedFile = require('./loadDefinedFile');
+var path = require('path');
+var fs = require('graceful-fs');
+var loadPackageProp = require('./loadPackageProp');
+var loadRc = require('./loadRc');
+var loadJs = require('./loadJs');
+var loadDefinedFile = require('./loadDefinedFile');
 
 module.exports = function (options) {
   // These cache Promises that resolve with results, not the results themselves
-  const fileCache = (options.cache) ? new Map() : null;
-  const directoryCache = (options.cache) ? new Map() : null;
-  const transform = options.transform || identityPromise;
+  var fileCache = (options.cache) ? new Map() : null;
+  var directoryCache = (options.cache) ? new Map() : null;
+  var transform = options.transform || identityPromise;
 
   function clearFileCache() {
     if (fileCache) fileCache.clear();
@@ -28,11 +28,11 @@ module.exports = function (options) {
 
   function load(searchPath, configPath) {
     if (configPath) {
-      const absoluteConfigPath = path.resolve(process.cwd(), configPath);
+      var absoluteConfigPath = path.resolve(process.cwd(), configPath);
       if (fileCache && fileCache.has(absoluteConfigPath)) {
         return fileCache.get(absoluteConfigPath);
       }
-      const result = loadDefinedFile(absoluteConfigPath, options)
+      var result = loadDefinedFile(absoluteConfigPath, options)
         .then(transform);
       if (fileCache) fileCache.set(absoluteConfigPath, result);
       return result;
@@ -40,11 +40,11 @@ module.exports = function (options) {
 
     if (!searchPath) return Promise.resolve(null);
 
-    const absoluteSearchPath = path.resolve(process.cwd(), searchPath);
+    var absoluteSearchPath = path.resolve(process.cwd(), searchPath);
 
     return isDirectory(absoluteSearchPath)
-      .then((searchPathIsDirectory) => {
-        const directory = (searchPathIsDirectory)
+      .then(function (searchPathIsDirectory) {
+        var directory = (searchPathIsDirectory)
           ? absoluteSearchPath
           : path.dirname(absoluteSearchPath);
         return searchDirectory(directory);
@@ -56,24 +56,24 @@ module.exports = function (options) {
       return directoryCache.get(directory);
     }
 
-    const result = Promise.resolve()
-      .then(() => {
+    var result = Promise.resolve()
+      .then(function () {
         if (!options.packageProp) return;
         return loadPackageProp(directory, options);
       })
-      .then((result) => {
+      .then(function (result) {
         if (result || !options.rc) return result;
         return loadRc(path.join(directory, options.rc), options);
       })
-      .then((result) => {
+      .then(function (result) {
         if (result || !options.js) return result;
         return loadJs(path.join(directory, options.js));
       })
-      .then((result) => {
+      .then(function (result) {
         if (result) return result;
 
-        const splitPath = directory.split(path.sep);
-        const nextDirectory = (splitPath.length > 1)
+        var splitPath = directory.split(path.sep);
+        var nextDirectory = (splitPath.length > 1)
           ? splitPath.slice(0, -1).join(path.sep)
           : null;
 
@@ -88,16 +88,16 @@ module.exports = function (options) {
   }
 
   return {
-    load,
-    clearFileCache,
-    clearDirectoryCache,
-    clearCaches,
+    load: load,
+    clearFileCache: clearFileCache,
+    clearDirectoryCache: clearDirectoryCache,
+    clearCaches: clearCaches,
   };
 };
 
 function isDirectory(filepath) {
-  return new Promise((resolve, reject) => {
-    fs.stat(filepath, (err, stats) => {
+  return new Promise(function (resolve, reject) {
+    fs.stat(filepath, function (err, stats) {
       if (err) return reject(err);
       return resolve(stats.isDirectory());
     });

--- a/lib/loadDefinedFile.js
+++ b/lib/loadDefinedFile.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const yaml = require('js-yaml');
-const parseJson = require('parse-json');
-const requireFromString = require('require-from-string');
-const readFile = require('./readFile');
+var yaml = require('js-yaml');
+var parseJson = require('parse-json');
+var requireFromString = require('require-from-string');
+var readFile = require('./readFile');
 
 module.exports = function (filepath, options) {
-  return readFile(filepath, { throwNotFound: true }).then((content) => {
-    const parsedConfig = (function () {
+  return readFile(filepath, { throwNotFound: true }).then(function (content) {
+    var parsedConfig = (function () {
       switch (options.format) {
         case 'json':
           return parseJson(content, filepath);
@@ -24,7 +24,7 @@ module.exports = function (filepath, options) {
 
     if (!parsedConfig) {
       throw new Error(
-        `Failed to parse "${filepath}'" as JSON, JS, or YAML.`
+        'Failed to parse "' + filepath + '" as JSON, JS, or YAML.'
       );
     }
 
@@ -36,8 +36,8 @@ module.exports = function (filepath, options) {
 };
 
 function tryAllParsing(content, filepath) {
-  return tryYaml(content, filepath, () => {
-    return tryRequire(content, filepath, () => {
+  return tryYaml(content, filepath, function () {
+    return tryRequire(content, filepath, function () {
       return null;
     });
   });
@@ -45,7 +45,7 @@ function tryAllParsing(content, filepath) {
 
 function tryYaml(content, filepath, cb) {
   try {
-    const result = yaml.safeLoad(content, {
+    var result = yaml.safeLoad(content, {
       filename: filepath,
     });
     if (typeof result === 'string') {

--- a/lib/loadJs.js
+++ b/lib/loadJs.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const requireFromString = require('require-from-string');
-const readFile = require('./readFile');
+var requireFromString = require('require-from-string');
+var readFile = require('./readFile');
 
 module.exports = function (filepath) {
-  return readFile(filepath).then((content) => {
+  return readFile(filepath).then(function (content) {
     if (!content) return null;
 
     return {

--- a/lib/loadPackageProp.js
+++ b/lib/loadPackageProp.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const path = require('path');
-const parseJson = require('parse-json');
-const readFile = require('./readFile');
+var path = require('path');
+var parseJson = require('parse-json');
+var readFile = require('./readFile');
 
 module.exports = function (packageDir, options) {
-  const packagePath = path.join(packageDir, 'package.json');
+  var packagePath = path.join(packageDir, 'package.json');
 
-  return readFile(packagePath).then((content) => {
+  return readFile(packagePath).then(function (content) {
     if (!content) return null;
-    const parsedContent = parseJson(content, packagePath);
-    const packagePropValue = parsedContent[options.packageProp];
+    var parsedContent = parseJson(content, packagePath);
+    var packagePropValue = parsedContent[options.packageProp];
     if (!packagePropValue) return null;
 
     return {

--- a/lib/loadRc.js
+++ b/lib/loadRc.js
@@ -1,22 +1,22 @@
 'use strict';
 
-const yaml = require('js-yaml');
-const parseJson = require('parse-json');
-const requireFromString = require('require-from-string');
-const readFile = require('./readFile');
+var yaml = require('js-yaml');
+var parseJson = require('parse-json');
+var requireFromString = require('require-from-string');
+var readFile = require('./readFile');
 
 module.exports = function (filepath, options) {
-  return loadExtensionlessRc().then((result) => {
+  return loadExtensionlessRc().then(function (result) {
     if (result) return result;
     if (options.rcExtensions) return loadRcWithExtensions();
     return null;
   });
 
   function loadExtensionlessRc() {
-    return readRcFile().then((content) => {
+    return readRcFile().then(function (content) {
       if (!content) return null;
 
-      const pasedConfig = (options.rcStrictJson)
+      var pasedConfig = (options.rcStrictJson)
         ? parseJson(content, filepath)
         : yaml.safeLoad(content, {
           filename: filepath,
@@ -29,9 +29,9 @@ module.exports = function (filepath, options) {
   }
 
   function loadRcWithExtensions() {
-    return readRcFile('json').then((content) => {
+    return readRcFile('json').then(function (content) {
       if (content) {
-        const successFilepath = `${filepath}.json`;
+        var successFilepath = filepath + '.json';
         return {
           config: parseJson(content, successFilepath),
           filepath: successFilepath,
@@ -40,33 +40,33 @@ module.exports = function (filepath, options) {
       // If not content was found in the file with extension,
       // try the next possible extension
       return readRcFile('yaml');
-    }).then((content) => {
+    }).then(function (content) {
       if (content) {
         // If the previous check returned an object with a config
         // property, then it succeeded and this step can be skipped
         if (content.config) return content;
         // If it just returned a string, then *this* check succeeded
-        const successFilepath = `${filepath}.yaml`;
+        var successFilepath = filepath + '.yaml';
         return {
           config: yaml.safeLoad(content, { filename: successFilepath }),
           filepath: successFilepath,
         };
       }
       return readRcFile('yml');
-    }).then((content) => {
+    }).then(function (content) {
       if (content) {
         if (content.config) return content;
-        const successFilepath = `${filepath}.yml`;
+        var successFilepath = filepath + '.yml';
         return {
           config: yaml.safeLoad(content, { filename: successFilepath }),
           filepath: successFilepath,
         };
       }
       return readRcFile('js');
-    }).then((content) => {
+    }).then(function (content) {
       if (content) {
         if (content.config) return content;
-        const successFilepath = `${filepath}.js`;
+        var successFilepath = filepath + '.js';
         return {
           config: requireFromString(content, successFilepath),
           filepath: successFilepath,
@@ -77,7 +77,9 @@ module.exports = function (filepath, options) {
   }
 
   function readRcFile(extension) {
-    const filepathWithExtension = (extension) ? `${filepath}.${extension}` : filepath;
+    var filepathWithExtension = (extension)
+      ? filepath + '.' + extension
+      : filepath;
     return readFile(filepathWithExtension);
   }
 };

--- a/lib/readFile.js
+++ b/lib/readFile.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const fs = require('graceful-fs');
+var fs = require('graceful-fs');
 
 module.exports = function (filepath, options) {
   options = options || {};
   options.throwNotFound = options.throwNotFound || false;
 
-  return new Promise((resolve, reject) => {
-    fs.readFile(filepath, 'utf8', (err, content) => {
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filepath, 'utf8', function (err, content) {
       if (err && err.code === 'ENOENT' && !options.throwNotFound) {
         return resolve(null);
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "graceful-fs": "^4.1.2",
     "js-yaml": "^3.4.3",
     "minimist": "^1.2.0",
+    "object-assign": "^4.1.0",
     "os-homedir": "^1.0.1",
     "parse-json": "^2.2.0",
     "require-from-string": "^1.1.0"
@@ -51,6 +52,6 @@
     "sinon": "1.17.6"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "scripts": {
-    "lint": "node-version-gte-4 && eslint .",
+    "lint": "node-version-gte-4 && eslint . || echo \"ESLint not supported\"",
     "ava": "ava test/*.test.js",
     "coverage": "nyc npm run ava && nyc report --reporter=html && open coverage/index.html",
     "test": "npm run ava && npm run lint",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "scripts": {
-    "lint": "eslint .",
+    "lint": "node-version-gte-4 && eslint .",
     "ava": "ava test/*.test.js",
     "coverage": "nyc npm run ava && nyc report --reporter=html && open coverage/index.html",
     "test": "npm run ava && npm run lint",
@@ -48,6 +48,7 @@
     "eslint-plugin-node": "^2.0.0",
     "expect": "^1.20.2",
     "lodash": "4.16.1",
+    "node-version-check": "^2.1.1",
     "nyc": "^8.3.0",
     "sinon": "1.17.6"
   },

--- a/test/assertSearchSequence.js
+++ b/test/assertSearchSequence.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const _ = require('lodash');
-const path = require('path');
+var _ = require('lodash');
+var path = require('path');
 
 module.exports = function (assert, readFileStub, searchPaths, startCount) {
   startCount = startCount || 0;
   assert.is(readFileStub.callCount, searchPaths.length + startCount);
-  searchPaths.forEach((searchPath, i) => {
+  searchPaths.forEach(function (searchPath, i) {
     assert.is(
       _.get(readFileStub.getCall(i + startCount), 'args[0]'),
       path.join(__dirname, searchPath),
-      `checked ${searchPath}`
+      'checked ' + searchPath
     );
   });
 };

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -1,78 +1,78 @@
 'use strict';
 
-const test = require('ava');
-const path = require('path');
-const cosmiconfig = require('..');
+var test = require('ava');
+var path = require('path');
+var cosmiconfig = require('..');
 
 function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
-test('defined file that does not exist', (assert) => {
-  const loadConfig = cosmiconfig().load;
+test('defined file that does not exist', function (assert) {
+  var loadConfig = cosmiconfig().load;
   return loadConfig(null, absolutePath('does/not/exist'))
     .then(assert.fail)
-    .catch((error) => {
+    .catch(function (error) {
       assert.is(error.code, 'ENOENT', 'with expected format');
     });
 });
 
-test('defined JSON file with syntax error, without expected format', (assert) => {
-  const loadConfig = cosmiconfig().load;
+test('defined JSON file with syntax error, without expected format', function (assert) {
+  var loadConfig = cosmiconfig().load;
   return loadConfig(null, absolutePath('fixtures/foo-invalid.json'))
     .then(assert.fail)
-    .catch((error) => {
+    .catch(function (error) {
       assert.truthy(/^Failed to parse/.test(error.message));
     });
 });
 
-test('defined JSON file with syntax error, with expected format', (assert) => {
-  const loadConfig = cosmiconfig(null, {
+test('defined JSON file with syntax error, with expected format', function (assert) {
+  var loadConfig = cosmiconfig(null, {
     format: 'json',
   }).load;
   return loadConfig(null, absolutePath('fixtures/foo-invalid.json'))
     .then(assert.fail)
-    .catch((error) => {
+    .catch(function (error) {
       assert.is(error.name, 'JSONError');
     });
 });
 
-test('defined YAML file with syntax error, without expected format', (assert) => {
-  const loadConfig = cosmiconfig().load;
+test('defined YAML file with syntax error, without expected format', function (assert) {
+  var loadConfig = cosmiconfig().load;
   return loadConfig(null, absolutePath('fixtures/foo-invalid.yaml'))
     .then(assert.fail)
-    .catch((error) => {
+    .catch(function (error) {
       assert.truthy(/^Failed to parse/.test(error.message));
     });
 });
 
-test('defined YAML file with syntax error, with expected format', (assert) => {
-  const loadConfig = cosmiconfig(null, {
+test('defined YAML file with syntax error, with expected format', function (assert) {
+  var loadConfig = cosmiconfig(null, {
     format: 'yaml',
   }).load;
   return loadConfig(null, absolutePath('fixtures/foo-invalid.yaml'))
     .then(assert.fail)
-    .catch((error) => {
+    .catch(function (error) {
       assert.is(error.name, 'YAMLException');
     });
 });
 
-test('defined JS file with syntax error, without expected format', (assert) => {
-  const loadConfig = cosmiconfig().load;
+test('defined JS file with syntax error, without expected format', function (assert) {
+  var loadConfig = cosmiconfig().load;
   return loadConfig(null, absolutePath('fixtures/foo-invalid.js'))
     .then(assert.fail)
-    .catch((error) => {
+    .catch(function (error) {
       assert.truthy(/^Failed to parse/.test(error.message));
     });
 });
 
-test('defined JS file with syntax error, with expected format', (assert) => {
-  const loadConfig = cosmiconfig(null, {
+test('defined JS file with syntax error, with expected format', function (assert) {
+  var loadConfig = cosmiconfig(null, {
     format: 'js',
   }).load;
   return loadConfig(null, absolutePath('fixtures/foo-invalid.js'))
     .then(assert.fail)
-    .catch((error) => {
+    .catch(function (error) {
       assert.truthy(!/^Failed to parse/.test(error.message));
     });
 });

--- a/test/successful-directories.test.js
+++ b/test/successful-directories.test.js
@@ -1,33 +1,35 @@
 'use strict';
 
-const test = require('ava');
-const sinon = require('sinon');
-const path = require('path');
-const fs = require('graceful-fs');
-const cosmiconfig = require('..');
-const assertSearchSequence = require('./assertSearchSequence');
+var test = require('ava');
+var sinon = require('sinon');
+var path = require('path');
+var fs = require('graceful-fs');
+var cosmiconfig = require('..');
+var assertSearchSequence = require('./assertSearchSequence');
 
 function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
-let statStub;
-let readFileStub;
+var statStub;
+var readFileStub;
 
-test.beforeEach(() => {
+test.beforeEach(function () {
   statStub = sinon.stub(fs, 'stat').yieldsAsync(null, {
-    isDirectory: () => true,
+    isDirectory: function () {
+      return true;
+    },
   });
 });
 
-test.afterEach(() => {
+test.afterEach(function () {
   if (readFileStub.restore) readFileStub.restore();
   if (statStub.restore) statStub.restore();
 });
 
-test.serial('find rc file in third searched dir, with a package.json lacking prop', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('find rc file in third searched dir, with a package.json lacking prop', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -44,15 +46,15 @@ test.serial('find rc file in third searched dir, with a package.json lacking pro
         callback(null, '{ "found": true }');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -70,9 +72,9 @@ test.serial('find rc file in third searched dir, with a package.json lacking pro
   });
 });
 
-test.serial('find package.json prop in second searched dir', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('find package.json prop in second searched dir', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -85,15 +87,15 @@ test.serial('find package.json prop in second searched dir', (assert) => {
         callback(null, '{ "author": "Todd", "foo": { "found": true } }');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -107,9 +109,9 @@ test.serial('find package.json prop in second searched dir', (assert) => {
   });
 });
 
-test.serial('find JS file in first searched dir', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('find JS file in first searched dir', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -122,15 +124,15 @@ test.serial('find JS file in first searched dir', (assert) => {
         callback(null, 'module.exports = { found: true };');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -143,9 +145,9 @@ test.serial('find JS file in first searched dir', (assert) => {
   });
 });
 
-test.serial('find package.json in second directory searched, with alternate names', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('find package.json in second directory searched, with alternate names', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.wowza'):
@@ -156,18 +158,18 @@ test.serial('find package.json in second directory searched, with alternate name
         callback(null, '{ "heeha": { "found": true } }');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     rc: '.wowza',
     js: 'wowzaConfig.js',
     packageProp: 'heeha',
     stopDir: absolutePath('.'),
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.wowza',
@@ -181,9 +183,9 @@ test.serial('find package.json in second directory searched, with alternate name
   });
 });
 
-test.serial('find rc file in third searched dir, skipping packageProp, with rcStrictJson', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('find rc file in third searched dir, skipping packageProp, with rcStrictJson', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -198,17 +200,17 @@ test.serial('find rc file in third searched dir, skipping packageProp, with rcSt
         callback(null, '{ "found": true }');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     packageProp: false,
     rcStrictJson: true,
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/foo.config.js',
@@ -223,9 +225,9 @@ test.serial('find rc file in third searched dir, skipping packageProp, with rcSt
   });
 });
 
-test.serial('find package.json prop in second searched dir, skipping js and rc', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('find package.json prop in second searched dir, skipping js and rc', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -238,17 +240,17 @@ test.serial('find package.json prop in second searched dir, skipping js and rc',
         callback(null, '{ "author": "Todd", "foo": { "found": true } }');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     js: false,
     rc: false,
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/package.json',
@@ -262,9 +264,9 @@ test.serial('find package.json prop in second searched dir, skipping js and rc',
 
 // RC file with specified extension
 
-test.serial('with rcExtensions, find .foorc.json in second searched dir', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('with rcExtensions, find .foorc.json in second searched dir', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -281,16 +283,16 @@ test.serial('with rcExtensions, find .foorc.json in second searched dir', (asser
         callback(null, '{ "found": true }');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -310,9 +312,9 @@ test.serial('with rcExtensions, find .foorc.json in second searched dir', (asser
   });
 });
 
-test.serial('with rcExtensions, find .foorc.yaml in first searched dir', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('with rcExtensions, find .foorc.yaml in first searched dir', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -323,16 +325,16 @@ test.serial('with rcExtensions, find .foorc.yaml in first searched dir', (assert
         callback(null, 'found: true');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -346,9 +348,9 @@ test.serial('with rcExtensions, find .foorc.yaml in first searched dir', (assert
   });
 });
 
-test.serial('with rcExtensions, find .foorc.yml in first searched dir', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('with rcExtensions, find .foorc.yml in first searched dir', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -360,16 +362,16 @@ test.serial('with rcExtensions, find .foorc.yml in first searched dir', (assert)
         callback(null, 'found: true');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -384,9 +386,9 @@ test.serial('with rcExtensions, find .foorc.yml in first searched dir', (assert)
   });
 });
 
-test.serial('with rcExtensions, find .foorc.js in first searched dir', (assert) => {
-  const startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', (searchPath, encoding, callback) => {
+test.serial('with rcExtensions, find .foorc.js in first searched dir', function (assert) {
+  var startDir = absolutePath('a/b/c/d/e/f');
+  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -399,16 +401,16 @@ test.serial('with rcExtensions, find .foorc.js in first searched dir', (assert) 
         callback(null, 'module.exports = { found: true };');
         break;
       default:
-        callback(new Error(`irrelevant path ${searchPath}`));
+        callback(new Error('irrelevant path ' + searchPath));
     }
   });
 
-  const loadConfig = cosmiconfig('foo', {
+  var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
 
-  return loadConfig(startDir).then((result) => {
+  return loadConfig(startDir).then(function (result) {
     assertSearchSequence(assert, readFileStub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const test = require('ava');
-const path = require('path');
-const cosmiconfig = require('..');
+var test = require('ava');
+var path = require('path');
+var cosmiconfig = require('..');
 
 function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
-test('defined JSON config path', (assert) => {
-  const loadConfig = cosmiconfig().load;
-  return loadConfig(null, absolutePath('fixtures/foo.json')).then((result) => {
+test('defined JSON config path', function (assert) {
+  var loadConfig = cosmiconfig().load;
+  return loadConfig(null, absolutePath('fixtures/foo.json')).then(function (result) {
     assert.deepEqual(result.config, {
       foo: true,
     });
@@ -18,9 +18,9 @@ test('defined JSON config path', (assert) => {
   });
 });
 
-test('defined YAML config path', (assert) => {
-  const loadConfig = cosmiconfig().load;
-  return loadConfig(null, absolutePath('fixtures/foo.yaml')).then((result) => {
+test('defined YAML config path', function (assert) {
+  var loadConfig = cosmiconfig().load;
+  return loadConfig(null, absolutePath('fixtures/foo.yaml')).then(function (result) {
     assert.deepEqual(result.config, {
       foo: true,
     });
@@ -28,9 +28,9 @@ test('defined YAML config path', (assert) => {
   });
 });
 
-test('defined JS config path', (assert) => {
-  const loadConfig = cosmiconfig().load;
-  return loadConfig(null, absolutePath('fixtures/foo.js')).then((result) => {
+test('defined JS config path', function (assert) {
+  var loadConfig = cosmiconfig().load;
+  return loadConfig(null, absolutePath('fixtures/foo.js')).then(function (result) {
     assert.deepEqual(result.config, {
       foo: true,
     });
@@ -38,9 +38,9 @@ test('defined JS config path', (assert) => {
   });
 });
 
-test('defined modulized JS config path', (assert) => {
-  const loadConfig = cosmiconfig().load;
-  return loadConfig(null, absolutePath('fixtures/foo-module.js')).then((result) => {
+test('defined modulized JS config path', function (assert) {
+  var loadConfig = cosmiconfig().load;
+  return loadConfig(null, absolutePath('fixtures/foo-module.js')).then(function (result) {
     assert.deepEqual(result.config, {
       foo: true,
     });


### PR DESCRIPTION
Closes #35.

To add Node 0.12 support:
- Replaced `const` and `let` with `var`.
- Replaced arrow functions with regular old anonymous functions.
- Replaced template literals with sad string concatenation.
- Added `object-assign` ponyfill.

@ai: Before I merge and release, would you please try this branch in `postcss-load-config` to double-check that I caught everything you need?