### PR TITLE
Don't throw on duplicate keys when parsing YAML

### DIFF
--- a/lib/loadDefinedFile.js
+++ b/lib/loadDefinedFile.js
@@ -14,6 +14,7 @@ module.exports = function (filepath, options) {
         case 'yaml':
           return yaml.safeLoad(content, {
             filename: filepath,
+            json: true,
           });
         case 'js':
           return requireFromString(content, filepath);
@@ -47,6 +48,7 @@ function tryYaml(content, filepath, cb) {
   try {
     var result = yaml.safeLoad(content, {
       filename: filepath,
+      json: true,
     });
     if (typeof result === 'string') {
       return cb();

--- a/lib/loadRc.js
+++ b/lib/loadRc.js
@@ -20,6 +20,7 @@ module.exports = function (filepath, options) {
         ? parseJson(content, filepath)
         : yaml.safeLoad(content, {
           filename: filepath,
+          json: true,
         });
       return {
         config: pasedConfig,
@@ -48,7 +49,10 @@ module.exports = function (filepath, options) {
         // If it just returned a string, then *this* check succeeded
         var successFilepath = filepath + '.yaml';
         return {
-          config: yaml.safeLoad(content, { filename: successFilepath }),
+          config: yaml.safeLoad(content, {
+            filename: successFilepath,
+            json: true,
+          }),
           filepath: successFilepath,
         };
       }
@@ -58,7 +62,10 @@ module.exports = function (filepath, options) {
         if (content.config) return content;
         var successFilepath = filepath + '.yml';
         return {
-          config: yaml.safeLoad(content, { filename: successFilepath }),
+          config: yaml.safeLoad(content, {
+            filename: successFilepath,
+            json: true,
+          }),
           filepath: successFilepath,
         };
       }


### PR DESCRIPTION
The [`json`](https://github.com/nodeca/js-yaml#safeload-string---options-) option of js-yaml allows duplicate keys to be parsed without throwing, making it compatible with `JSON.parse` in this regard.

Resolves https://github.com/stylelint/stylelint/issues/2051.