### PR TITLE
Remove graceful-fs

### DIFF
--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var path = require('path');
-var fs = require('graceful-fs');
+var fs = require('fs');
 var loadPackageProp = require('./loadPackageProp');
 var loadRc = require('./loadRc');
 var loadJs = require('./loadJs');

--- a/lib/readFile.js
+++ b/lib/readFile.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var fs = require('graceful-fs');
+var fs = require('fs');
 
 module.exports = function (filepath, options) {
   options = options || {};

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "lint": "node-version-gte-4 && eslint . || echo \"ESLint not supported\"",
     "ava": "ava test/*.test.js",
     "coverage": "nyc npm run ava && nyc report --reporter=html && open coverage/index.html",
-    "test": "npm run ava && npm run lint",
-    "prepublish": "npm test"
+    "test": "npm run ava && npm run lint"
   },
   "repository": {
     "type": "git",
@@ -33,7 +32,6 @@
   },
   "homepage": "https://github.com/davidtheclark/cosmiconfig#readme",
   "dependencies": {
-    "graceful-fs": "^4.1.2",
     "js-yaml": "^3.4.3",
     "minimist": "^1.2.0",
     "object-assign": "^4.1.0",

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -3,7 +3,7 @@
 var test = require('ava');
 var sinon = require('sinon');
 var path = require('path');
-var fs = require('graceful-fs');
+var fs = require('fs');
 var cosmiconfig = require('..');
 var assertSearchSequence = require('./assertSearchSequence');
 

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -3,7 +3,7 @@
 var test = require('ava');
 var sinon = require('sinon');
 var path = require('path');
-var fs = require('graceful-fs');
+var fs = require('fs');
 var _ = require('lodash');
 var cosmiconfig = require('..');
 

--- a/test/successful-directories.test.js
+++ b/test/successful-directories.test.js
@@ -3,7 +3,7 @@
 var test = require('ava');
 var sinon = require('sinon');
 var path = require('path');
-var fs = require('graceful-fs');
+var fs = require('fs');
 var cosmiconfig = require('..');
 var assertSearchSequence = require('./assertSearchSequence');
 


### PR DESCRIPTION
I found out that `graceful-js` is somehow causing the module to accumulate memory that is not adequately garbage-collected. By removing `graceful-fs` in favor of the native `fs` module, I was able to solve https://github.com/stylelint/stylelint/issues/2168.

I filed an issue in `graceful-fs` about this: https://github.com/isaacs/node-graceful-fs/issues/102.