### PR TITLE
Adds the user home to the search path

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = function (moduleName, options) {
     rcStrictJson: false,
     stopDir: oshomedir(),
     cache: true,
+    ensureUserHome: true,
   }, options);
 
   if (options.argv && parsedCliArgs[options.argv]) {

--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -6,12 +6,14 @@ var loadPackageProp = require('./loadPackageProp');
 var loadRc = require('./loadRc');
 var loadJs = require('./loadJs');
 var loadDefinedFile = require('./loadDefinedFile');
+var oshomedir = require('os-homedir');
 
 module.exports = function (options) {
   // These cache Promises that resolve with results, not the results themselves
   var fileCache = (options.cache) ? new Map() : null;
   var directoryCache = (options.cache) ? new Map() : null;
   var transform = options.transform || identityPromise;
+  var mustEnsureUserHome = false;
 
   function clearFileCache() {
     if (fileCache) fileCache.clear();
@@ -41,6 +43,7 @@ module.exports = function (options) {
     if (!searchPath) return Promise.resolve(null);
 
     var absoluteSearchPath = path.resolve(process.cwd(), searchPath);
+    mustEnsureUserHome = options.ensureUserHome && (process.cwd().indexOf(oshomedir) !== 0);
 
     return isDirectory(absoluteSearchPath)
       .then(function (searchPathIsDirectory) {
@@ -51,7 +54,7 @@ module.exports = function (options) {
       });
   }
 
-  function searchDirectory(directory) {
+  function searchDirectory(directory, lastSearchDirectory) {
     if (directoryCache && directoryCache.has(directory)) {
       return directoryCache.get(directory);
     }
@@ -77,7 +80,13 @@ module.exports = function (options) {
           ? splitPath.slice(0, -1).join(path.sep)
           : null;
 
-        if (!nextDirectory || directory === options.stopDir) return null;
+        if (!nextDirectory || directory === options.stopDir || lastSearchDirectory) {
+          if (mustEnsureUserHome && directory !== oshomedir()) {
+            return searchDirectory(oshomedir(), true);
+          } else {
+            return null;
+          }
+        }
 
         return searchDirectory(nextDirectory);
       })


### PR DESCRIPTION
Following to #59, added the functionality that look into user's home for the config files.
That code broke 2 tests, which I fixed and added alternate versions to include the user's home to the tests.