### PR TITLE
chore: replace json-parse-helpfulerror with parse-json

### DIFF
--- a/lib/parseJson.js
+++ b/lib/parseJson.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var jph = require('json-parse-helpfulerror');
+var parseJson = require('parse-json');
 
 module.exports = function (json, filepath) {
   try {
-    return jph.parse(json);
+    return parseJson(json);
   } catch (err) {
     err.message = 'JSON Error in ' + filepath + ':\n' + err.message;
     throw err;

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "dependencies": {
     "is-directory": "^0.3.1",
     "js-yaml": "^3.4.3",
-    "json-parse-helpfulerror": "^1.0.3",
     "minimist": "^1.2.0",
     "object-assign": "^4.1.0",
     "os-homedir": "^1.0.1",
+    "parse-json": "^2.2.0",
     "require-from-string": "^1.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,10 +1070,6 @@ istanbul-reports@^1.0.0:
   dependencies:
     handlebars "^4.0.3"
 
-jju@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jju/-/jju-1.3.0.tgz#dadd9ef01924bc728b03f2f7979bdbd62f7a2aaa"
-
 js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
@@ -1088,12 +1084,6 @@ js-yaml@^3.4.3, js-yaml@^3.5.1:
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
-
-json-parse-helpfulerror@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz#13f14ce02eed4e981297b64eb9e3b932e2dd13dc"
-  dependencies:
-    jju "^1.1.0"
 
 json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The `json-parse-helpfulerror` package uses `jju` which uses a license that is not
OSI approved.

Fixes #65.