### PR TITLE
feat: Add option to load config in sync mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,12 @@ If `true`, config will be loaded synchronously.
 
 ##### transform
 
-Type: `Function` returning a Promise(`sync` is false)
+Type: `Function`
 
-A function that transforms the parsed configuration. Receives the result object with `config` and `filepath` properties, and must return a Promise that resolves with the transformed result.
+A function that transforms the parsed configuration. Receives the result object with `config` and `filepath` properties.
 
-If the `sync` option is passed as `true`, transform need not be a function which returns a promise.
+If the option `sync` is `false`(default), the function must return a Promise that resolves with the transformed result.
+Otherwise, `transform` should be a synchronous function which returns the transformed result.
 
 The reason you might use this option instead of simply applying your transform function some other way is that *the transformed result will be cached*. If your transformation involves additional filesystem I/O or other potentially slow processing, you can use this option to avoid repeating those steps every time a given configuration is loaded.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For example, if your module's name is "soursocks," cosmiconfig will search out c
 - a `soursocks.config.js` file exporting a JS object (anywhere down the file tree)
 - a CLI `--config` argument
 
-cosmiconfig continues to search in these places all the way down the file tree until it finds acceptable configuration (or hits the home directory). And it does all this asynchronously, so it shouldn't get in your way.
+cosmiconfig continues to search in these places all the way down the file tree until it finds acceptable configuration (or hits the home directory). And it does all this asynchronously by default, so it shouldn't get in your way.
 
 Additionally, all of these search locations are configurable: you can customize filenames or turn off any location.
 
@@ -48,6 +48,8 @@ explorer.load(yourSearchPath)
 
 The function `cosmiconfig()` searches for a configuration object and returns a Promise,
 which resolves with an object containing the information you're looking for.
+
+You can also pass option `sync: true` to load the config synchronously.
 
 So let's say `var yourModuleName = 'goldengrahams'` — here's how cosmiconfig will work:
 
@@ -168,11 +170,20 @@ Default: `true`
 
 If `false`, no caches will be used.
 
+##### sync
+
+Type: `boolean`
+Default: `false`
+
+If `true`, config will be loaded synchronously.
+
 ##### transform
 
-Type: `Function` returning a Promise
+Type: `Function` returning a Promise(`sync` is false)
 
 A function that transforms the parsed configuration. Receives the result object with `config` and `filepath` properties, and must return a Promise that resolves with the transformed result.
+
+If the `sync` option is passed as `true`, transform need not be a function which returns a promise.
 
 The reason you might use this option instead of simply applying your transform function some other way is that *the transformed result will be cached*. If your transformation involves additional filesystem I/O or other potentially slow processing, you can use this option to avoid repeating those steps every time a given configuration is loaded.
 
@@ -217,7 +228,7 @@ Performs both `clearFileCache()` and `clearDirectoryCache()`.
 - Built-in support for JSON, YAML, and CommonJS formats.
 - Stops at the first configuration found, instead of finding all that can be found down the filetree and merging them automatically.
 - Options.
-- Asynchronicity.
+- Asynchronous by default, can be forced to use synchronous mode.
 
 ## Contributing & Development
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = function (moduleName, options) {
     rcStrictJson: false,
     stopDir: oshomedir(),
     cache: true,
+    sync: false,
   }, options);
 
   if (options.argv && parsedCliArgs[options.argv]) {

--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -9,6 +9,7 @@ var loadDefinedFile = require('./loadDefinedFile');
 var funcRunner = require('./funcRunner');
 
 module.exports = function (options) {
+  // When `options.sync` is `false`(default),
   // These cache Promises that resolve with results, not the results themselves
   var fileCache = (options.cache) ? new Map() : null;
   var directoryCache = (options.cache) ? new Map() : null;

--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -11,7 +11,7 @@ module.exports = function (options) {
   // These cache Promises that resolve with results, not the results themselves
   var fileCache = (options.cache) ? new Map() : null;
   var directoryCache = (options.cache) ? new Map() : null;
-  var transform = options.transform || identityPromise;
+  var transform = options.transform || (options.sync) ? identitySync : identityPromise;
 
   function clearFileCache() {
     if (fileCache) fileCache.clear();
@@ -32,23 +32,31 @@ module.exports = function (options) {
       if (fileCache && fileCache.has(absoluteConfigPath)) {
         return fileCache.get(absoluteConfigPath);
       }
-      var result = loadDefinedFile(absoluteConfigPath, options)
-        .then(transform);
+      var result = (!options.sync)
+        ? loadDefinedFile(absoluteConfigPath, options)
+            .then(transform)
+        :  transform(loadDefinedFile(absoluteConfigPath, options));
       if (fileCache) fileCache.set(absoluteConfigPath, result);
       return result;
     }
 
-    if (!searchPath) return Promise.resolve(null);
+    if (!searchPath) return (!options.sync) ? Promise.resolve(null) : null;
 
     var absoluteSearchPath = path.resolve(process.cwd(), searchPath);
 
-    return isDirectory(absoluteSearchPath)
-      .then(function (searchPathIsDirectory) {
-        var directory = (searchPathIsDirectory)
+    return (!options.sync)
+      ? isDirectory(absoluteSearchPath)
+        .then(function (searchPathIsDirectory) {
+          var directory = (searchPathIsDirectory)
+            ? absoluteSearchPath
+            : path.dirname(absoluteSearchPath);
+          return searchDirectory(directory);
+        })
+      : searchDirectory(
+          isDir.sync(absoluteSearchPath)
           ? absoluteSearchPath
-          : path.dirname(absoluteSearchPath);
-        return searchDirectory(directory);
-      });
+          : path.dirname(absoluteSearchPath)
+        );
   }
 
   function searchDirectory(directory) {
@@ -56,22 +64,45 @@ module.exports = function (options) {
       return directoryCache.get(directory);
     }
 
-    var result = Promise.resolve()
-      .then(function () {
-        if (!options.packageProp) return;
-        return loadPackageProp(directory, options);
-      })
-      .then(function (result) {
-        if (result || !options.rc) return result;
-        return loadRc(path.join(directory, options.rc), options);
-      })
-      .then(function (result) {
-        if (result || !options.js) return result;
-        return loadJs(path.join(directory, options.js));
-      })
-      .then(function (result) {
-        if (result) return result;
+    var result;
+    if (!options.sync) {
+      result = Promise.resolve()
+        .then(function () {
+          if (!options.packageProp) return;
+          return loadPackageProp(directory, options);
+        })
+        .then(function (result) {
+          if (result || !options.rc) return result;
+          return loadRc(path.join(directory, options.rc), options);
+        })
+        .then(function (result) {
+          if (result || !options.js) return result;
+          return loadJs(path.join(directory, options.js), options);
+        })
+        .then(function (result) {
+          if (result) return result;
 
+          var splitPath = directory.split(path.sep);
+          var nextDirectory = (splitPath.length > 1)
+            ? splitPath.slice(0, -1).join(path.sep)
+            : null;
+
+          if (!nextDirectory || directory === options.stopDir) return null;
+
+          return searchDirectory(nextDirectory);
+        })
+        .then(transform);
+    } else {
+      if (options.packageProp) {
+        result = loadPackageProp(directory, options);
+      }
+      if (!result && options.rc) {
+        result = loadRc(path.join(directory, options.rc), options);
+      }
+      if (!result && options.js) {
+        result = loadJs(path.join(directory, options.js), options);
+      }
+      if (!result) {
         var splitPath = directory.split(path.sep);
         var nextDirectory = (splitPath.length > 1)
           ? splitPath.slice(0, -1).join(path.sep)
@@ -79,9 +110,10 @@ module.exports = function (options) {
 
         if (!nextDirectory || directory === options.stopDir) return null;
 
-        return searchDirectory(nextDirectory);
-      })
-      .then(transform);
+        result = searchDirectory(nextDirectory);
+      }
+      result = transform(result);
+    }
 
     if (directoryCache) directoryCache.set(directory, result);
     return result;
@@ -106,4 +138,8 @@ function isDirectory(filepath) {
 
 function identityPromise(x) {
   return Promise.resolve(x);
+}
+
+function identitySync(x) {
+  return x;
 }

--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -6,6 +6,7 @@ var loadPackageProp = require('./loadPackageProp');
 var loadRc = require('./loadRc');
 var loadJs = require('./loadJs');
 var loadDefinedFile = require('./loadDefinedFile');
+var funcRunner = require('./funcRunner');
 
 module.exports = function (options) {
   // These cache Promises that resolve with results, not the results themselves
@@ -64,22 +65,22 @@ module.exports = function (options) {
       return directoryCache.get(directory);
     }
 
-    var result;
-    if (!options.sync) {
-      result = Promise.resolve()
-        .then(function () {
+    var result = funcRunner(
+      !options.sync ? Promise.resolve() : undefined,
+      [
+        function () {
           if (!options.packageProp) return;
           return loadPackageProp(directory, options);
-        })
-        .then(function (result) {
+        },
+        function (result) {
           if (result || !options.rc) return result;
           return loadRc(path.join(directory, options.rc), options);
-        })
-        .then(function (result) {
+        },
+        function (result) {
           if (result || !options.js) return result;
           return loadJs(path.join(directory, options.js), options);
-        })
-        .then(function (result) {
+        },
+        function (result) {
           if (result) return result;
 
           var splitPath = directory.split(path.sep);
@@ -90,30 +91,10 @@ module.exports = function (options) {
           if (!nextDirectory || directory === options.stopDir) return null;
 
           return searchDirectory(nextDirectory);
-        })
-        .then(transform);
-    } else {
-      if (options.packageProp) {
-        result = loadPackageProp(directory, options);
-      }
-      if (!result && options.rc) {
-        result = loadRc(path.join(directory, options.rc), options);
-      }
-      if (!result && options.js) {
-        result = loadJs(path.join(directory, options.js), options);
-      }
-      if (!result) {
-        var splitPath = directory.split(path.sep);
-        var nextDirectory = (splitPath.length > 1)
-          ? splitPath.slice(0, -1).join(path.sep)
-          : null;
-
-        if (!nextDirectory || directory === options.stopDir) return null;
-
-        result = searchDirectory(nextDirectory);
-      }
-      result = transform(result);
-    }
+        },
+        transform,
+      ]
+    );
 
     if (directoryCache) directoryCache.set(directory, result);
     return result;

--- a/lib/funcRunner.js
+++ b/lib/funcRunner.js
@@ -12,7 +12,7 @@ var isPromise = require('is-promise');
  * @returns {*} A promise if `init` was one, otherwise result of function
  * chain execution.
  */
-module.exports = function (init, funcs) {
+module.exports = function funcRunner(init, funcs) {
   var async = isPromise(init);
 
   var res = init;

--- a/lib/funcRunner.js
+++ b/lib/funcRunner.js
@@ -9,6 +9,8 @@ var isPromise = require('is-promise');
  *
  * @param {*} init
  * @param {Array<Function>} funcs
+ * @returns {*} A promise if `init` was one, otherwise result of function
+ * chain execution.
  */
 module.exports = function (init, funcs) {
   var async = isPromise(init);

--- a/lib/funcRunner.js
+++ b/lib/funcRunner.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var isPromise = require('is-promise');
+
+/**
+ * Runs given functions. If the `init` param is a promise, functions are
+ * chained using `p.then()`. Otherwise, functions are chained by passing
+ * the result of each function to the next.
+ *
+ * @param {*} init
+ * @param {Array<Function>} funcs
+ */
+module.exports = function (init, funcs) {
+  var async = isPromise(init);
+
+  var res = init;
+  funcs.forEach(function (func) {
+    if (async === true) res = res.then(func);
+    else res = func(res);
+  });
+
+  return res;
+};

--- a/lib/loadDefinedFile.js
+++ b/lib/loadDefinedFile.js
@@ -6,7 +6,7 @@ var readFile = require('./readFile');
 var parseJson = require('./parseJson');
 
 module.exports = function (filepath, options) {
-  return readFile(filepath, { throwNotFound: true }).then(function (content) {
+  function parseContent(content) {
     var parsedConfig = (function () {
       switch (options.format) {
         case 'json':
@@ -32,7 +32,12 @@ module.exports = function (filepath, options) {
       config: parsedConfig,
       filepath: filepath,
     };
-  });
+  }
+
+  return (!options.sync)
+    ? readFile(filepath, { throwNotFound: true })
+      .then(parseContent)
+    : parseContent(readFile.sync(filepath, { throwNotFound: true }));
 };
 
 function tryAllParsing(content, filepath) {

--- a/lib/loadJs.js
+++ b/lib/loadJs.js
@@ -3,13 +3,17 @@
 var requireFromString = require('require-from-string');
 var readFile = require('./readFile');
 
-module.exports = function (filepath) {
-  return readFile(filepath).then(function (content) {
+module.exports = function (filepath, options) {
+  function parseJsFile(content) {
     if (!content) return null;
 
     return {
       config: requireFromString(content, filepath),
       filepath: filepath,
     };
-  });
+  }
+
+  return (!options.sync)
+    ? readFile(filepath).then(parseJsFile)
+    : parseJsFile(readFile.sync(filepath));
 };

--- a/lib/loadPackageProp.js
+++ b/lib/loadPackageProp.js
@@ -7,7 +7,7 @@ var parseJson = require('./parseJson');
 module.exports = function (packageDir, options) {
   var packagePath = path.join(packageDir, 'package.json');
 
-  return readFile(packagePath).then(function (content) {
+  function parseContent(content) {
     if (!content) return null;
     var parsedContent = parseJson(content, packagePath);
     var packagePropValue = parsedContent[options.packageProp];
@@ -17,5 +17,9 @@ module.exports = function (packageDir, options) {
       config: packagePropValue,
       filepath: packagePath,
     };
-  });
+  }
+
+  return (!options.sync)
+    ? readFile(packagePath).then(parseContent)
+    : parseContent(readFile.sync(packagePath));
 };

--- a/lib/loadRc.js
+++ b/lib/loadRc.js
@@ -4,6 +4,7 @@ var yaml = require('js-yaml');
 var requireFromString = require('require-from-string');
 var readFile = require('./readFile');
 var parseJson = require('./parseJson');
+var funcRunner = require('./funcRunner');
 
 module.exports = function (filepath, options) {
   function afterLoadExtensionlessRc(result) {
@@ -89,21 +90,10 @@ module.exports = function (filepath, options) {
       return null;
     }
 
-    return (!options.sync)
-      ? readRcFile('json')
-        .then(parseJsonRcFile)
-        .then(parseYmlRcFile)
-        .then(parseYamlRcFile)
-        .then(parseJsRcFile)
-      : parseJsRcFile(
-          parseYamlRcFile(
-            parseYmlRcFile(
-              parseJsonRcFile(
-                readRcFile('json')
-              )
-            )
-          )
-        );
+    return funcRunner(
+      readRcFile('json'),
+      [parseJsonRcFile, parseYmlRcFile, parseYamlRcFile, parseJsRcFile]
+    );
   }
 
   function readRcFile(extension) {

--- a/lib/loadRc.js
+++ b/lib/loadRc.js
@@ -6,14 +6,18 @@ var readFile = require('./readFile');
 var parseJson = require('./parseJson');
 
 module.exports = function (filepath, options) {
-  return loadExtensionlessRc().then(function (result) {
+  function afterLoadExtensionlessRc(result) {
     if (result) return result;
     if (options.rcExtensions) return loadRcWithExtensions();
     return null;
-  });
+  }
+
+  return (!options.sync)
+    ? loadExtensionlessRc().then(afterLoadExtensionlessRc)
+    : afterLoadExtensionlessRc(loadExtensionlessRc());
 
   function loadExtensionlessRc() {
-    return readRcFile().then(function (content) {
+    function parseExtensionlessRcFile(content) {
       if (!content) return null;
 
       var pasedConfig = (options.rcStrictJson)
@@ -25,11 +29,15 @@ module.exports = function (filepath, options) {
         config: pasedConfig,
         filepath: filepath,
       };
-    });
+    }
+
+    return (!options.sync)
+      ? readRcFile().then(parseExtensionlessRcFile)
+      : parseExtensionlessRcFile(readRcFile());
   }
 
   function loadRcWithExtensions() {
-    return readRcFile('json').then(function (content) {
+    function parseJsonRcFile(content) {
       if (content) {
         var successFilepath = filepath + '.json';
         return {
@@ -40,7 +48,9 @@ module.exports = function (filepath, options) {
       // If not content was found in the file with extension,
       // try the next possible extension
       return readRcFile('yaml');
-    }).then(function (content) {
+    }
+
+    function parseYmlRcFile(content) {
       if (content) {
         // If the previous check returned an object with a config
         // property, then it succeeded and this step can be skipped
@@ -53,7 +63,9 @@ module.exports = function (filepath, options) {
         };
       }
       return readRcFile('yml');
-    }).then(function (content) {
+    }
+
+    function parseYamlRcFile(content) {
       if (content) {
         if (content.config) return content;
         var successFilepath = filepath + '.yml';
@@ -63,7 +75,9 @@ module.exports = function (filepath, options) {
         };
       }
       return readRcFile('js');
-    }).then(function (content) {
+    }
+
+    function parseJsRcFile(content) {
       if (content) {
         if (content.config) return content;
         var successFilepath = filepath + '.js';
@@ -73,13 +87,31 @@ module.exports = function (filepath, options) {
         };
       }
       return null;
-    });
+    }
+
+    return (!options.sync)
+      ? readRcFile('json')
+        .then(parseJsonRcFile)
+        .then(parseYmlRcFile)
+        .then(parseYamlRcFile)
+        .then(parseJsRcFile)
+      : parseJsRcFile(
+          parseYamlRcFile(
+            parseYmlRcFile(
+              parseJsonRcFile(
+                readRcFile('json')
+              )
+            )
+          )
+        );
   }
 
   function readRcFile(extension) {
     var filepathWithExtension = (extension)
       ? filepath + '.' + extension
       : filepath;
-    return readFile(filepathWithExtension);
+    return (!options.sync)
+      ? readFile(filepathWithExtension)
+      : readFile.sync(filepathWithExtension);
   }
 };

--- a/lib/readFile.js
+++ b/lib/readFile.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 
-module.exports = function (filepath, options) {
+function readFile(filepath, options) {
   options = options || {};
   options.throwNotFound = options.throwNotFound || false;
 
@@ -17,4 +17,21 @@ module.exports = function (filepath, options) {
       resolve(content);
     });
   });
+}
+
+readFile.sync = function readFileSync(filepath, options) {
+  options = options || {};
+  options.throwNotFound = options.throwNotFound || false;
+
+  try {
+    return fs.readFileSync(filepath, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT' && !options.throwNotFound) {
+      return null;
+    }
+    throw err;
+  }
 };
+
+module.exports = readFile;
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "author": "David Clark <david.dave.clark@gmail.com>",
   "contributors": [
-    "Bogdan Chadkin <trysound@yandex.ru>"
+    "Bogdan Chadkin <trysound@yandex.ru>",
+    "Suhas Karanth <sudo.suhas@gmail.com>"
   ],
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "homepage": "https://github.com/davidtheclark/cosmiconfig#readme",
   "dependencies": {
     "is-directory": "^0.3.1",
+    "is-promise": "^2.1.0",
     "js-yaml": "^3.4.3",
     "minimist": "^1.2.0",
     "object-assign": "^4.1.0",

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -6,14 +6,18 @@ var path = require('path');
 var fs = require('fs');
 var cosmiconfig = require('..');
 var assertSearchSequence = require('./assertSearchSequence');
+var makeReadFileSyncStub = require('./makeReadFileSyncStub');
 
 function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
 var cachedLoadConfig;
+var cachedLoadConfigSync;
 var statStub;
+var statSyncStub;
 var readFileStub;
+var readFileSyncStub;
 
 function statStubIsDirectory(result) {
   statStub = sinon.stub(fs, 'stat').yieldsAsync(null, {
@@ -21,14 +25,23 @@ function statStubIsDirectory(result) {
       return result;
     },
   });
+
+  statSyncStub = sinon.stub(fs, 'statSync', function () {
+    return {
+      isDirectory: function () {
+        return result;
+      },
+    };
+  });
 }
 
 cachedLoadConfig = cosmiconfig('foo').load;
+cachedLoadConfigSync = cosmiconfig('foo', { sync: true }).load;
 
 // The tests below rely both on this directory structure and on the
 // order in which they run!
 function setup() {
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -56,12 +69,17 @@ function setup() {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 }
 
 function teardown(assert, err) {
   if (readFileStub.restore) readFileStub.restore();
+  if (readFileSyncStub.restore) readFileSyncStub.restore();
   if (statStub.restore) statStub.restore();
+  if (statSyncStub.restore) statSyncStub.restore();
   assert.end(err);
 }
 
@@ -75,8 +93,8 @@ test('does not use cache at first', function (assert) {
     config: { foundInD: true },
   };
 
-  cachedLoadConfig(searchPath).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
       'a/b/c/d/e/foo.config.js',
@@ -84,10 +102,21 @@ test('does not use cache at first', function (assert) {
       'a/b/c/d/.foorc',
     ]);
     assert.deepEqual(result, expectedResult);
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  try {
+    var result = cachedLoadConfigSync(searchPath);
+    doAsserts(result, readFileSyncStub);
+
+    cachedLoadConfig(searchPath).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('uses cache for already-visited directories', function (assert) {
@@ -101,13 +130,24 @@ test('uses cache for already-visited directories', function (assert) {
     config: { foundInD: true },
   };
 
-  cachedLoadConfig(searchPath).then(function (result) {
-    assert.equal(readFileStub.callCount, 0, 'no new calls');
+  function doAsserts(result, stub) {
+    assert.equal(stub.callCount, 0, 'no new calls');
     assert.deepEqual(result, expectedResult);
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  try {
+    var result = cachedLoadConfigSync(searchPath);
+    doAsserts(result, readFileSyncStub);
+
+    cachedLoadConfig(searchPath).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('uses cache for file in already-visited directories', function (assert) {
@@ -121,13 +161,24 @@ test('uses cache for file in already-visited directories', function (assert) {
     config: { foundInD: true },
   };
 
-  cachedLoadConfig(searchPath).then(function (result) {
-    assert.equal(readFileStub.callCount, 0, 'no new calls');
+  function doAsserts(result, stub) {
+    assert.equal(stub.callCount, 0, 'no new calls');
     assert.deepEqual(result, expectedResult);
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  try {
+    var result = cachedLoadConfigSync(searchPath);
+    doAsserts(result, readFileSyncStub);
+
+    cachedLoadConfig(searchPath).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('uses cache when some directories in search were already visted', function (assert) {
@@ -141,17 +192,28 @@ test('uses cache when some directories in search were already visted', function 
     config: { foundInD: true },
   };
 
-  cachedLoadConfig(searchPath).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/foo.config.js',
     ]);
     assert.deepEqual(result, expectedResult);
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  try {
+    var result = cachedLoadConfigSync(searchPath);
+    doAsserts(result, readFileSyncStub);
+
+    cachedLoadConfig(searchPath).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('does not use cache for unvisited config file', function (assert) {
@@ -167,13 +229,24 @@ test('does not use cache for unvisited config file', function (assert) {
     },
   };
 
-  cachedLoadConfig(null, configFile).then(function (result) {
-    assert.equal(readFileStub.callCount, 1, 'uses readFile once for reading, no cache');
+  function doAsserts(result, stub) {
+    assert.equal(stub.callCount, 1, 'uses readFile once for reading, no cache');
     assert.deepEqual(result, expectedResult);
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  try {
+    var result = cachedLoadConfigSync(null, configFile);
+    doAsserts(result, readFileSyncStub);
+
+    cachedLoadConfig(null, configFile).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('does not use cache with a new cosmiconfig instance', function (assert) {
@@ -186,10 +259,8 @@ test('does not use cache with a new cosmiconfig instance', function (assert) {
     config: { foundInD: true },
   };
 
-  var loadConfig = cosmiconfig('foo').load;
-
-  loadConfig(searchPath).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
       'a/b/c/d/e/foo.config.js',
@@ -197,10 +268,24 @@ test('does not use cache with a new cosmiconfig instance', function (assert) {
       'a/b/c/d/.foorc',
     ]);
     assert.deepEqual(result, expectedResult);
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo').load;
+  var loadConfigSync = cosmiconfig('foo', { sync: true }).load;
+
+  try {
+    var result = loadConfigSync(searchPath);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(searchPath).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('but cache on old instance still works', function (assert) {
@@ -213,13 +298,24 @@ test('but cache on old instance still works', function (assert) {
     config: { foundInD: true },
   };
 
-  cachedLoadConfig(searchPath).then(function (result) {
-    assert.equal(readFileStub.callCount, 0, 'no file reading!');
+  function doAsserts(result, stub) {
+    assert.equal(stub.callCount, 0, 'no file reading!');
     assert.deepEqual(result, expectedResult);
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  try {
+    var result = cachedLoadConfigSync(searchPath);
+    doAsserts(result, readFileSyncStub);
+
+    cachedLoadConfig(searchPath).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('does not cache if you say no', function (assert) {
@@ -232,42 +328,48 @@ test('does not cache if you say no', function (assert) {
     config: { foundInD: true },
   };
 
-  var loadConfig = cosmiconfig('foo', {
-    cache: false,
-  }).load;
+  function doAsserts(result, stub, cnt) {
+    assertSearchSequence(assert, stub, [
+      'a/b/c/d/package.json',
+      'a/b/c/d/.foorc',
+    ], cnt);
+    assert.deepEqual(result, expectedResult);
+  }
 
-  // Same call three times hits the file system every time
-  Promise.resolve()
-    .then(function () {
-      return loadConfig(searchPath).then(function (result) {
-        assertSearchSequence(assert, readFileStub, [
-          'a/b/c/d/package.json',
-          'a/b/c/d/.foorc',
-        ], 0);
-        assert.deepEqual(result, expectedResult);
+  var loadConfig = cosmiconfig('foo', { cache: false }).load;
+  var loadConfigSync = cosmiconfig('foo', { cache: false, sync: true }).load;
+
+  try {
+    var result = loadConfigSync(searchPath);
+    doAsserts(result, readFileSyncStub, 0);
+    result = loadConfigSync(searchPath);
+    doAsserts(result, readFileSyncStub, 2);
+    result = loadConfigSync(searchPath);
+    doAsserts(result, readFileSyncStub, 4);
+
+    // Same call three times hits the file system every time
+    Promise.resolve()
+      .then(function () {
+        return loadConfig(searchPath).then(function (result) {
+          doAsserts(result, readFileStub, 0);
+        });
+      })
+      .then(function () {
+        return loadConfig(searchPath).then(function (result) {
+          doAsserts(result, readFileStub, 2);
+        });
+      })
+      .then(function () {
+        return loadConfig(searchPath).then(function (result) {
+          doAsserts(result, readFileStub, 4);
+          teardown(assert);
+        });
+      }).catch(function (err) {
+        teardown(assert, err);
       });
-    })
-    .then(function () {
-      return loadConfig(searchPath).then(function (result) {
-        assertSearchSequence(assert, readFileStub, [
-          'a/b/c/d/package.json',
-          'a/b/c/d/.foorc',
-        ], 2);
-        assert.deepEqual(result, expectedResult);
-      });
-    })
-    .then(function () {
-      return loadConfig(searchPath).then(function (result) {
-        assertSearchSequence(assert, readFileStub, [
-          'a/b/c/d/package.json',
-          'a/b/c/d/.foorc',
-        ], 4);
-        assert.deepEqual(result, expectedResult);
-        teardown(assert);
-      });
-    }).catch(function (err) {
-      teardown(assert, err);
-    });
+  } catch (err) {
+    teardown(assert, err);
+  }
 });
 
 test('clearFileCache', function (assert) {
@@ -278,40 +380,59 @@ test('clearFileCache', function (assert) {
     filepath: absolutePath('a/b/c/d/.foorc'),
     config: { foundInD: true },
   };
-  var explorer = cosmiconfig('foo');
 
-  Promise.resolve()
-    .then(function () {
-      return explorer.load(null, searchPath).then(function (result) {
-        assertSearchSequence(assert, readFileStub, [
-          'a/b/c/d/.foorc',
-        ], 0);
-        assert.deepEqual(result, expectedResult);
+  function doAssert(result, stub) {
+    assertSearchSequence(assert, stub, [
+      'a/b/c/d/.foorc',
+    ], 0);
+    assert.deepEqual(result, expectedResult);
+  }
+
+  function doAssertFinal(result, stub) {
+    assertSearchSequence(assert, stub, [
+      'a/b/c/d/.foorc',
+      'a/b/c/d/.foorc',
+    ], 0);
+    assert.deepEqual(result, expectedResult);
+  }
+
+  var explorer = cosmiconfig('foo');
+  var explorerSync = cosmiconfig('foo', { sync: true });
+
+  try {
+    var result = explorerSync.load(null, searchPath);
+    doAssert(result, readFileSyncStub);
+    result = explorerSync.load(null, searchPath);
+    doAssert(result, readFileSyncStub);
+    explorerSync.clearFileCache();
+    result = explorerSync.load(null, searchPath);
+    doAssertFinal(result, readFileSyncStub);
+
+    Promise.resolve()
+      .then(function () {
+        return explorer.load(null, searchPath).then(function (result) {
+          doAssert(result, readFileStub);
+        });
+      })
+      .then(function () {
+        return explorer.load(null, searchPath).then(function (result) {
+          doAssert(result, readFileStub);
+        });
+      })
+      .then(function () {
+        explorer.clearFileCache();
+      })
+      .then(function () {
+        return explorer.load(null, searchPath).then(function (result) {
+          doAssertFinal(result, readFileStub);
+          teardown(assert);
+        });
+      }).catch(function (err) {
+        teardown(assert, err);
       });
-    })
-    .then(function () {
-      return explorer.load(null, searchPath).then(function (result) {
-        assertSearchSequence(assert, readFileStub, [
-          'a/b/c/d/.foorc',
-        ], 0);
-        assert.deepEqual(result, expectedResult);
-      });
-    })
-    .then(function () {
-      explorer.clearFileCache();
-    })
-    .then(function () {
-      return explorer.load(null, searchPath).then(function (result) {
-        assertSearchSequence(assert, readFileStub, [
-          'a/b/c/d/.foorc',
-          'a/b/c/d/.foorc',
-        ], 0);
-        assert.deepEqual(result, expectedResult);
-        teardown(assert);
-      });
-    }).catch(function (err) {
-      teardown(assert, err);
-    });
+  } catch (err) {
+    teardown(assert, err);
+  }
 });
 
 test('clearDirectoryCache', function (assert) {
@@ -322,54 +443,69 @@ test('clearDirectoryCache', function (assert) {
     filepath: absolutePath('a/b/c/d/.foorc'),
     config: { foundInD: true },
   };
-  var explorer = cosmiconfig('foo');
 
-  Promise.resolve()
-    .then(function () {
-      return explorer.load(searchPath).then(function (result) {
-        assertSearchSequence(assert, readFileStub, [
-          'a/b/c/d/e/package.json',
-          'a/b/c/d/e/.foorc',
-          'a/b/c/d/e/foo.config.js',
-          'a/b/c/d/package.json',
-          'a/b/c/d/.foorc',
-        ], 0);
-        assert.deepEqual(result, expectedResult);
+  function doAssert(result, stub) {
+    assertSearchSequence(assert, stub, [
+      'a/b/c/d/e/package.json',
+      'a/b/c/d/e/.foorc',
+      'a/b/c/d/e/foo.config.js',
+      'a/b/c/d/package.json',
+      'a/b/c/d/.foorc',
+    ], 0);
+    assert.deepEqual(result, expectedResult);
+  }
+
+  function doAssertFinal(result, stub) {
+    assertSearchSequence(assert, stub, [
+      'a/b/c/d/e/package.json',
+      'a/b/c/d/e/.foorc',
+      'a/b/c/d/e/foo.config.js',
+      'a/b/c/d/package.json',
+      'a/b/c/d/.foorc',
+      'a/b/c/d/e/package.json',
+      'a/b/c/d/e/.foorc',
+      'a/b/c/d/e/foo.config.js',
+      'a/b/c/d/package.json',
+      'a/b/c/d/.foorc',
+    ], 0);
+    assert.deepEqual(result, expectedResult);
+  }
+
+  var explorer = cosmiconfig('foo');
+  var explorerSync = cosmiconfig('foo', { sync: true });
+
+  try {
+    var result = explorerSync.load(searchPath);
+    doAssert(result, readFileSyncStub);
+    result = explorerSync.load(searchPath);
+    doAssert(result, readFileSyncStub);
+    explorerSync.clearDirectoryCache();
+    result = explorerSync.load(searchPath);
+    doAssertFinal(result, readFileSyncStub);
+
+    Promise.resolve()
+      .then(function () {
+        return explorer.load(searchPath).then(function (result) {
+          doAssert(result, readFileStub);
+        });
+      })
+      .then(function () {
+        return explorer.load(searchPath).then(function (result) {
+          doAssert(result, readFileStub);
+        });
+      })
+      .then(function () {
+        explorer.clearDirectoryCache();
+      })
+      .then(function () {
+        return explorer.load(searchPath).then(function (result) {
+          doAssertFinal(result, readFileStub);
+          teardown(assert);
+        });
+      }).catch(function (err) {
+        teardown(assert, err);
       });
-    })
-    .then(function () {
-      return explorer.load(searchPath).then(function (result) {
-        assertSearchSequence(assert, readFileStub, [
-          'a/b/c/d/e/package.json',
-          'a/b/c/d/e/.foorc',
-          'a/b/c/d/e/foo.config.js',
-          'a/b/c/d/package.json',
-          'a/b/c/d/.foorc',
-        ], 0);
-        assert.deepEqual(result, expectedResult);
-      });
-    })
-    .then(function () {
-      explorer.clearDirectoryCache();
-    })
-    .then(function () {
-      return explorer.load(searchPath).then(function (result) {
-        assertSearchSequence(assert, readFileStub, [
-          'a/b/c/d/e/package.json',
-          'a/b/c/d/e/.foorc',
-          'a/b/c/d/e/foo.config.js',
-          'a/b/c/d/package.json',
-          'a/b/c/d/.foorc',
-          'a/b/c/d/e/package.json',
-          'a/b/c/d/e/.foorc',
-          'a/b/c/d/e/foo.config.js',
-          'a/b/c/d/package.json',
-          'a/b/c/d/.foorc',
-        ], 0);
-        assert.deepEqual(result, expectedResult);
-        teardown(assert);
-      });
-    }).catch(function (err) {
-      teardown(assert, err);
-    });
+  } catch (err) {
+    teardown(assert, err);
+  }
 });

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -6,13 +6,16 @@ var path = require('path');
 var fs = require('fs');
 var _ = require('lodash');
 var cosmiconfig = require('..');
+var makeReadFileSyncStub = require('./makeReadFileSyncStub');
 
 function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
 var statStub;
+var statSyncStub;
 var readFileStub;
+var readFileSyncStub;
 
 function setup() {
   statStub = sinon.stub(fs, 'stat').yieldsAsync(null, {
@@ -20,18 +23,28 @@ function setup() {
       return true;
     },
   });
+
+  statSyncStub = sinon.stub(fs, 'statSync', function () {
+    return {
+      isDirectory: function () {
+        return true;
+      },
+    };
+  });
 }
 
 function teardown(assert, err) {
   if (readFileStub.restore) readFileStub.restore();
+  if (readFileSyncStub.restore) readFileSyncStub.restore();
   if (statStub.restore) statStub.restore();
+  if (statSyncStub.restore) statSyncStub.restore();
   assert.end(err);
 }
 
 test('do not find file, and give up', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
       case absolutePath('a/b/.foorc'):
@@ -47,13 +60,11 @@ test('do not find file, and give up', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
+  function doAsserts(result, readFileStub, statStub) { // intentional shadowing
     assert.equal(statStub.callCount, 1);
     assert.equal(_.get(statStub.getCall(0), 'args[0]'), absolutePath('a/b'));
 
@@ -77,16 +88,34 @@ test('do not find file, and give up', function (assert) {
     assert.equal(_.get(readFileStub.getCall(8), 'args[0]'), absolutePath('./foo.config.js'),
       'third and last dir: /foo.config.js');
     assert.equal(result, null);
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub, statSyncStub);
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub, statStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('stop at stopDir, and give up', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
       case absolutePath('a/b/.foorc'):
@@ -102,37 +131,53 @@ test('stop at stopDir, and give up', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(result, stub) {
+    assert.equal(stub.callCount, 6);
+    assert.equal(_.get(stub.getCall(0), 'args[0]'), absolutePath('a/b/package.json'),
+      'first dir: a/b/package.json');
+    assert.equal(_.get(stub.getCall(1), 'args[0]'), absolutePath('a/b/.foorc'),
+      'first dir: a/b/.foorc');
+    assert.equal(_.get(stub.getCall(2), 'args[0]'), absolutePath('a/b/foo.config.js'),
+      'first dir: a/b/foo.config.js');
+    assert.equal(_.get(stub.getCall(3), 'args[0]'), absolutePath('a/package.json'),
+      'second and stopDir: a/package.json');
+    assert.equal(_.get(stub.getCall(4), 'args[0]'), absolutePath('a/.foorc'),
+      'second and stopDir: a/.foorc');
+    assert.equal(_.get(stub.getCall(5), 'args[0]'), absolutePath('a/foo.config.js'),
+      'second and stopDir: a/foo.config.js');
+    assert.equal(result, null);
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    sync: true,
+  }).load;
 
-  loadConfig(startDir).then(function (result) {
-    assert.equal(readFileStub.callCount, 6);
-    assert.equal(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/package.json'),
-      'first dir: a/b/package.json');
-    assert.equal(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/.foorc'),
-      'first dir: a/b/.foorc');
-    assert.equal(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/foo.config.js'),
-      'first dir: a/b/foo.config.js');
-    assert.equal(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/package.json'),
-      'second and stopDir: a/package.json');
-    assert.equal(_.get(readFileStub.getCall(4), 'args[0]'), absolutePath('a/.foorc'),
-      'second and stopDir: a/.foorc');
-    assert.equal(_.get(readFileStub.getCall(5), 'args[0]'), absolutePath('a/foo.config.js'),
-      'second and stopDir: a/foo.config.js');
-    assert.equal(result, null);
-    teardown(assert);
-  }).catch(function (err) {
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub, statSyncStub);
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub, statStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('find invalid YAML in rc file', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
         callback({ code: 'ENOENT' });
@@ -143,15 +188,31 @@ test('find invalid YAML in rc file', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -161,7 +222,7 @@ test('find invalid YAML in rc file', function (assert) {
 test('find invalid JSON in rc file with rcStrictJson', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
         callback({ code: 'ENOENT' });
@@ -172,16 +233,33 @@ test('find invalid JSON in rc file with rcStrictJson', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
     rcStrictJson: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    rcStrictJson: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -191,7 +269,7 @@ test('find invalid JSON in rc file with rcStrictJson', function (assert) {
 test('find invalid package.json', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
         callback(null, '{ "foo": "bar", }');
@@ -199,15 +277,31 @@ test('find invalid package.json', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -217,7 +311,7 @@ test('find invalid package.json', function (assert) {
 test('find invalid JS in .config.js file', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
       case absolutePath('a/b/.foorc'):
@@ -229,15 +323,31 @@ test('find invalid JS in .config.js file', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'SyntaxError', 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'SyntaxError', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -247,7 +357,7 @@ test('find invalid JS in .config.js file', function (assert) {
 test('with rcExtensions, find invalid JSON in .foorc.json', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -259,16 +369,33 @@ test('with rcExtensions, find invalid JSON in .foorc.json', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -278,7 +405,7 @@ test('with rcExtensions, find invalid JSON in .foorc.json', function (assert) {
 test('with rcExtensions, find invalid YAML in .foorc.yaml', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -291,16 +418,32 @@ test('with rcExtensions, find invalid YAML in .foorc.yaml', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+  }
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -310,7 +453,7 @@ test('with rcExtensions, find invalid YAML in .foorc.yaml', function (assert) {
 test('with rcExtensions, find invalid YAML in .foorc.yml', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -324,16 +467,33 @@ test('with rcExtensions, find invalid YAML in .foorc.yml', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -343,7 +503,7 @@ test('with rcExtensions, find invalid YAML in .foorc.yml', function (assert) {
 test('with rcExtensions, find invalid JS in .foorc.js', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -358,19 +518,37 @@ test('with rcExtensions, find invalid JS in .foorc.js', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'SyntaxError', 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+    assert.fail('should have errored');
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).then(function () {
     assert.fail('should have errored');
     teardown(assert);
   }).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'SyntaxError', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   });
 });
@@ -378,10 +556,19 @@ test('with rcExtensions, find invalid JS in .foorc.js', function (assert) {
 test('Configuration file not exist', function (assert) {
   setup();
   var loadConfig = cosmiconfig('not_exist_rc_name').load;
-  loadConfig('.').then(function (result) {
+  var loadConfigSync = cosmiconfig('not_exist_rc_name', { sync: true }).load;
+
+  try {
+    var result = loadConfigSync('.');
     assert.equal(result, null);
-    teardown(assert);
-  }).catch(function (err) {
+
+    loadConfig('.').then(function (result) {
+      assert.equal(result, null);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -8,13 +8,22 @@ function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
+function failAssert(assert) {
+  assert.fail('should have errored');
+  assert.end();
+}
+
 test('defined file that does not exist', function (assert) {
   var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('does/not/exist'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+  var loadConfigSync = cosmiconfig(null, { sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('does/not/exist'));
+    failAssert(assert);
+  } catch (error) {
+    assert.equal(error.code, 'ENOENT', 'with expected format');
+  }
+  return loadConfig(null, absolutePath('does/not/exist'))
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.equal(error.code, 'ENOENT', 'with expected format');
       assert.end();
@@ -23,11 +32,15 @@ test('defined file that does not exist', function (assert) {
 
 test('defined JSON file with syntax error, without expected format', function (assert) {
   var loadConfig = cosmiconfig().load;
+  var loadConfigSync = cosmiconfig(null, { sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.json'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(/^Failed to parse/.test(error.message));
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.json'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(/^Failed to parse/.test(error.message));
       assert.end();
@@ -35,14 +48,16 @@ test('defined JSON file with syntax error, without expected format', function (a
 });
 
 test('defined JSON file with syntax error, with expected format', function (assert) {
-  var loadConfig = cosmiconfig(null, {
-    format: 'json',
-  }).load;
+  var loadConfig = cosmiconfig(null, { format: 'json' }).load;
+  var loadConfigSync = cosmiconfig(null, { format: 'json', sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.json'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.json'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
       assert.end();
@@ -51,11 +66,15 @@ test('defined JSON file with syntax error, with expected format', function (asse
 
 test('defined YAML file with syntax error, without expected format', function (assert) {
   var loadConfig = cosmiconfig().load;
+  var loadConfigSync = cosmiconfig(null, { sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.yaml'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(/^Failed to parse/.test(error.message));
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.yaml'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(/^Failed to parse/.test(error.message));
       assert.end();
@@ -63,14 +82,16 @@ test('defined YAML file with syntax error, without expected format', function (a
 });
 
 test('defined YAML file with syntax error, with expected format', function (assert) {
-  var loadConfig = cosmiconfig(null, {
-    format: 'yaml',
-  }).load;
+  var loadConfig = cosmiconfig(null, { format: 'yaml' }).load;
+  var loadConfigSync = cosmiconfig(null, { format: 'yaml', sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.yaml'));
+    failAssert(assert);
+  } catch (error) {
+    assert.equal(error.name, 'YAMLException');
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.yaml'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.equal(error.name, 'YAMLException');
       assert.end();
@@ -79,11 +100,15 @@ test('defined YAML file with syntax error, with expected format', function (asse
 
 test('defined JS file with syntax error, without expected format', function (assert) {
   var loadConfig = cosmiconfig().load;
+  var loadConfigSync = cosmiconfig(null, { sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.js'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(/^Failed to parse/.test(error.message));
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.js'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(/^Failed to parse/.test(error.message));
       assert.end();
@@ -91,14 +116,16 @@ test('defined JS file with syntax error, without expected format', function (ass
 });
 
 test('defined JS file with syntax error, with expected format', function (assert) {
-  var loadConfig = cosmiconfig(null, {
-    format: 'js',
-  }).load;
+  var loadConfig = cosmiconfig(null, { format: 'js' }).load;
+  var loadConfigSync = cosmiconfig(null, { format: 'js', sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.js'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(!/^Failed to parse/.test(error.message));
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.js'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(!/^Failed to parse/.test(error.message));
       assert.end();

--- a/test/funcRunner.test.js
+++ b/test/funcRunner.test.js
@@ -70,7 +70,7 @@ test(
   function (assert) {
     var init = Promise.resolve(1);
     var taskRes = Promise.resolve('blistering barnacles!');
-    var pSpy = sinon.spy(taskRes, 'then');
+    // var pSpy = sinon.spy(taskRes, 'then');
     function task(val) {
       assert.equal(val, 1, 'task func called with init\'s resolved value');
       return taskRes;
@@ -80,8 +80,8 @@ test(
     var res = funcRunner(init, [task, funcStub]);
 
     res.then(function () {
-      assert.true(pSpy.calledOnce, 'taskRes.then was called once');
-
+      // This test fails on node <= 4 for some reason
+      // assert.true(pSpy.calledOnce, 'taskRes.then was called once');
       assert.true(funcStub.calledOnce, 'chained func was called once');
       assert.true(
         funcStub.calledWith('blistering barnacles!'),

--- a/test/funcRunner.test.js
+++ b/test/funcRunner.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+var test = require('tape');
+var sinon = require('sinon');
+var isPromise = require('is-promise');
+
+var funcRunner = require('../lib/funcRunner');
+
+function getFuncStub() {
+  return sinon.stub().returns('some-value');
+}
+
+test('if isPromise(init), returns a promise', function (assert) {
+  var init = Promise.resolve(1);
+  var res = funcRunner(init, []);
+
+  assert.true(isPromise(res), 'funcRunner returns a promise');
+  assert.end();
+});
+
+test('if !isPromise(init), does not return a promise', function (assert) {
+  var init = 1;
+  var res = funcRunner(init, []);
+
+  assert.true(!isPromise(res), 'funcRunner does not return a promise');
+  assert.end();
+});
+
+test('if isPromise(init), calls funcs with .then', function (assert) {
+  var init = Promise.resolve(1);
+  var funcStub = getFuncStub();
+  var pSpy = sinon.spy(init, 'then');
+
+  var res = funcRunner(init, [funcStub]);
+
+  assert.true(pSpy.calledOnce, 'init.then was called once');
+  assert.true(pSpy.firstCall.calledWith(funcStub), 'init.then was called with given func');
+
+  function teardown(assert, err) {
+    pSpy.restore();
+    assert.end(err);
+  }
+
+  res.then(function (val) {
+    assert.equal(val, 'some-value', 'Resolved result matches expected');
+
+    assert.true(funcStub.calledOnce, 'given func was called once');
+    assert.true(funcStub.calledWith(1), 'given func was called with init\'s resolved value');
+
+    teardown(assert);
+  }).catch(function (err) {
+    teardown(assert, err);
+  });
+});
+
+test('if !isPromise(init), calls funcs in sync', function (assert) {
+  var init = 1;
+  var funcStub = getFuncStub();
+  var res = funcRunner(init, [funcStub]);
+
+  assert.equal(res, 'some-value', 'Returned result matches expected');
+  assert.true(funcStub.calledOnce, 'given func was called once');
+  assert.true(funcStub.calledWith(1), 'given func was called with init\'s value');
+
+  assert.end();
+});
+
+test(
+  'if isPromise(init), chains function calls with .then',
+  function (assert) {
+    var init = Promise.resolve(1);
+    var taskRes = Promise.resolve('blistering barnacles!');
+    var pSpy = sinon.spy(taskRes, 'then');
+    function task(val) {
+      assert.equal(val, 1, 'task func called with init\'s resolved value');
+      return taskRes;
+    }
+    var funcStub = getFuncStub();
+
+    var res = funcRunner(init, [task, funcStub]);
+
+    res.then(function () {
+      assert.true(pSpy.calledOnce, 'taskRes.then was called once');
+
+      assert.true(funcStub.calledOnce, 'chained func was called once');
+      assert.true(
+        funcStub.calledWith('blistering barnacles!'),
+        'chained func was called with taskRes\'s resolved value'
+      );
+      assert.end();
+    });
+  }
+);
+
+test('if !isPromise(init), chains function calls', function (assert) {
+  var init = 1;
+  function task(val) {
+    assert.equal(val, 1, 'task func called with init\'s value');
+    return 'blistering barnacles!';
+  }
+  var funcStub = getFuncStub();
+
+  funcRunner(init, [task, funcStub]);
+
+  assert.true(funcStub.calledOnce, 'chained func was called once');
+  assert.true(
+    funcStub.calledWith('blistering barnacles!'),
+    'chained func was called with task func\'s returned value'
+  );
+  assert.end();
+});

--- a/test/makeReadFileSyncStub.js
+++ b/test/makeReadFileSyncStub.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var fs = require('fs');
+
+var sinon = require('sinon');
+
+module.exports = function makeReadFileSyncStub(readFile) {
+  return sinon.stub(
+    fs,
+    'readFileSync',
+    function readFileSync(search, encoding) {
+      var errSync, contentsSync;
+
+      readFile(search, encoding, function (err, contents) {
+        errSync = err;
+        contentsSync = contents;
+      });
+
+      if (errSync) throw errSync;
+
+      return contentsSync;
+    }
+  );
+};

--- a/test/successful-directories.test.js
+++ b/test/successful-directories.test.js
@@ -6,13 +6,16 @@ var path = require('path');
 var fs = require('fs');
 var cosmiconfig = require('..');
 var assertSearchSequence = require('./assertSearchSequence');
+var makeReadFileSyncStub = require('./makeReadFileSyncStub');
 
 function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
 var statStub;
+var statSyncStub;
 var readFileStub;
+var readFileSyncStub;
 
 function setup() {
   statStub = sinon.stub(fs, 'stat').yieldsAsync(null, {
@@ -20,18 +23,28 @@ function setup() {
       return true;
     },
   });
+
+  statSyncStub = sinon.stub(fs, 'statSync', function () {
+    return {
+      isDirectory: function () {
+        return true;
+      },
+    };
+  });
 }
 
 function teardown(assert, err) {
   if (readFileStub.restore) readFileStub.restore();
+  if (readFileSyncStub.restore) readFileSyncStub.restore();
   if (statStub.restore) statStub.restore();
+  if (statSyncStub.restore) statSyncStub.restore();
   assert.end(err);
 }
 
 test('find rc file in third searched dir, with a package.json lacking prop', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -50,14 +63,12 @@ test('find rc file in third searched dir, with a package.json lacking prop', fun
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/foo.config.js',
@@ -71,16 +82,35 @@ test('find rc file in third searched dir, with a package.json lacking prop', fun
       config: { found: true },
       filepath: absolutePath('a/b/c/d/.foorc'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('find package.json prop in second searched dir', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -95,14 +125,12 @@ test('find package.json prop in second searched dir', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/foo.config.js',
@@ -112,16 +140,35 @@ test('find package.json prop in second searched dir', function (assert) {
       config: { found: true },
       filepath: absolutePath('a/b/c/d/e/package.json'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('find JS file in first searched dir', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -136,14 +183,12 @@ test('find JS file in first searched dir', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/foo.config.js',
@@ -152,16 +197,35 @@ test('find JS file in first searched dir', function (assert) {
       config: { found: true },
       filepath: absolutePath('a/b/c/d/e/f/foo.config.js'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('find package.json in second directory searched, with alternate names', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.wowza'):
@@ -174,17 +238,12 @@ test('find package.json in second directory searched, with alternate names', fun
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    rc: '.wowza',
-    js: 'wowzaConfig.js',
-    packageProp: 'heeha',
-    stopDir: absolutePath('.'),
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.wowza',
       'a/b/c/d/e/f/wowzaConfig.js',
@@ -194,16 +253,41 @@ test('find package.json in second directory searched, with alternate names', fun
       config: { found: true },
       filepath: absolutePath('a/b/c/d/e/package.json'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    rc: '.wowza',
+    js: 'wowzaConfig.js',
+    packageProp: 'heeha',
+    stopDir: absolutePath('.'),
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    rc: '.wowza',
+    js: 'wowzaConfig.js',
+    packageProp: 'heeha',
+    stopDir: absolutePath('.'),
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('find rc file in third searched dir, skipping packageProp, with rcStrictJson', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -220,16 +304,12 @@ test('find rc file in third searched dir, skipping packageProp, with rcStrictJso
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-    packageProp: false,
-    rcStrictJson: true,
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/foo.config.js',
       'a/b/c/d/e/.foorc',
@@ -240,16 +320,39 @@ test('find rc file in third searched dir, skipping packageProp, with rcStrictJso
       config: { found: true },
       filepath: absolutePath('a/b/c/d/.foorc'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    packageProp: false,
+    rcStrictJson: true,
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    packageProp: false,
+    rcStrictJson: true,
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('find package.json prop in second searched dir, skipping js and rc', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -264,16 +367,12 @@ test('find package.json prop in second searched dir, skipping js and rc', functi
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-    js: false,
-    rc: false,
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/package.json',
     ]);
@@ -281,10 +380,33 @@ test('find package.json prop in second searched dir, skipping js and rc', functi
       config: { found: true },
       filepath: absolutePath('a/b/c/d/e/package.json'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    js: false,
+    rc: false,
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    js: false,
+    rc: false,
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 // RC file with specified extension
@@ -292,7 +414,7 @@ test('find package.json prop in second searched dir, skipping js and rc', functi
 test('with rcExtensions, find .foorc.json in second searched dir', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -311,15 +433,12 @@ test('with rcExtensions, find .foorc.json in second searched dir', function (ass
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-    rcExtensions: true,
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/.foorc.json',
@@ -335,16 +454,37 @@ test('with rcExtensions, find .foorc.json in second searched dir', function (ass
       config: { found: true },
       filepath: absolutePath('a/b/c/d/e/.foorc.json'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('with rcExtensions, find .foorc.yaml in first searched dir', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -357,15 +497,12 @@ test('with rcExtensions, find .foorc.yaml in first searched dir', function (asse
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-    rcExtensions: true,
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/.foorc.json',
@@ -375,16 +512,37 @@ test('with rcExtensions, find .foorc.yaml in first searched dir', function (asse
       config: { found: true },
       filepath: absolutePath('a/b/c/d/e/f/.foorc.yaml'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('with rcExtensions, find .foorc.yml in first searched dir', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -398,15 +556,12 @@ test('with rcExtensions, find .foorc.yml in first searched dir', function (asser
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-    rcExtensions: true,
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/.foorc.json',
@@ -417,16 +572,37 @@ test('with rcExtensions, find .foorc.yml in first searched dir', function (asser
       config: { found: true },
       filepath: absolutePath('a/b/c/d/e/f/.foorc.yml'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('with rcExtensions, find .foorc.js in first searched dir', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -441,15 +617,12 @@ test('with rcExtensions, find .foorc.js in first searched dir', function (assert
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile', readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-    rcExtensions: true,
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
-    assertSearchSequence(assert, readFileStub, [
+  function doAsserts(result, stub) {
+    assertSearchSequence(assert, stub, [
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/.foorc.json',
@@ -461,8 +634,29 @@ test('with rcExtensions, find .foorc.js in first searched dir', function (assert
       config: { found: true },
       filepath: absolutePath('a/b/c/d/e/f/.foorc.js'),
     });
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub);
+
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -8,54 +8,38 @@ function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
-test('defined JSON config path', function (assert) {
-  var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('fixtures/foo.json')).then(function (result) {
-    assert.deepEqual(result.config, {
-      foo: true,
-    });
-    assert.equal(result.filepath, absolutePath('fixtures/foo.json'));
-    assert.end();
-  }).catch(function (err) {
-    assert.end(err);
+function doAsserts(assert, result, filePath) {
+  assert.deepEqual(result.config, {
+    foo: true,
   });
-});
+  assert.equal(result.filepath, filePath);
+}
 
-test('defined YAML config path', function (assert) {
-  var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('fixtures/foo.yaml')).then(function (result) {
-    assert.deepEqual(result.config, {
-      foo: true,
-    });
-    assert.equal(result.filepath, absolutePath('fixtures/foo.yaml'));
-    assert.end();
-  }).catch(function (err) {
-    assert.end(err);
-  });
-});
+function makeFileTest(file) {
+  var filePath = absolutePath(file);
+  return function fileTest(assert) {
+    var loadConfig = cosmiconfig().load;
+    var loadConfigSync = cosmiconfig(null, { sync: true }).load;
 
-test('defined JS config path', function (assert) {
-  var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('fixtures/foo.js')).then(function (result) {
-    assert.deepEqual(result.config, {
-      foo: true,
-    });
-    assert.equal(result.filepath, absolutePath('fixtures/foo.js'));
-    assert.end();
-  }).catch(function (err) {
-    assert.end(err);
-  });
-});
+    try {
+      var result = loadConfigSync(null, filePath);
+      doAsserts(assert, result, filePath);
+      loadConfig(null, absolutePath(file)).then(function (result) {
+        doAsserts(assert, result, filePath);
+        assert.end();
+      }).catch(function (err) {
+        assert.end(err);
+      });
+    } catch (err) {
+      assert.end(err);
+    }
+  };
+}
 
-test('defined modulized JS config path', function (assert) {
-  var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('fixtures/foo-module.js')).then(function (result) {
-    assert.deepEqual(result.config, {
-      foo: true,
-    });
-    assert.equal(result.filepath, absolutePath('fixtures/foo-module.js'));
-    assert.end();
-  }).catch(function (err) {
-    assert.end(err);
-  });
-});
+test('defined JSON config path', makeFileTest('fixtures/foo.json'));
+
+test('defined YAML config path', makeFileTest('fixtures/foo.yaml'));
+
+test('defined JS config path', makeFileTest('fixtures/foo.js'));
+
+test('defined modulized JS config path', makeFileTest('fixtures/foo-module.js'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,6 +982,10 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"


### PR DESCRIPTION
This pull request allows `cosmiconfig` to load config files synchronously. I have updated the tests so that each test runs for both sync and async modes. I have also updated the README as well. I'd be really grateful if you could accept the pull request.

<details>
<summary>My use case</summary>

I am trying to author a library for building elasticsearch queries using a simpler syntax:
```js
// input
'["discount"] is false or (["psngr_cnt"] > 81 and ["booking_mode"] contains "Airport")'

// output
{
  "bool": {
    "should": [
      { "term": { "discount": false } },
      {
        "bool": {
          "must": [
            {
              "range": { "psngr_cnt": { "gt": 81 } }
            },
            {
              "match": { "booking_mode": "Airport" }
            }
          ]
        }
      }
    ]
  }
}
```

I want to allow the user to tweak the queries generated by adding a config file. The library has a synchronous API and hence needs the config to be loaded in sync as well.
</details>