### PR TITLE
Fix transform not being run

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For example, if your module's name is "soursocks," cosmiconfig will search out c
 - a `soursocks.config.js` file exporting a JS object (anywhere down the file tree)
 - a CLI `--config` argument
 
-cosmiconfig continues to search in these places all the way down the file tree until it finds acceptable configuration (or hits the home directory). And it does all this asynchronously, so it shouldn't get in your way.
+cosmiconfig continues to search in these places all the way down the file tree until it finds acceptable configuration (or hits the home directory).
 
 Additionally, all of these search locations are configurable: you can customize filenames or turn off any location.
 
@@ -48,6 +48,8 @@ explorer.load(yourSearchPath)
 
 The function `cosmiconfig()` searches for a configuration object and returns a Promise,
 which resolves with an object containing the information you're looking for.
+
+You can also pass option `sync: true` to load the config synchronously, returning the config itself.
 
 So let's say `var yourModuleName = 'goldengrahams'` — here's how cosmiconfig will work:
 
@@ -168,13 +170,29 @@ Default: `true`
 
 If `false`, no caches will be used.
 
+##### sync
+
+Type: `boolean`
+Default: `false`
+
+If `true`, config will be loaded synchronously.
+
 ##### transform
 
-Type: `Function` returning a Promise
+Type: `Function`
 
-A function that transforms the parsed configuration. Receives the result object with `config` and `filepath` properties, and must return a Promise that resolves with the transformed result.
+A function that transforms the parsed configuration. Receives the result object with `config` and `filepath` properties.
+
+If the option `sync` is `false` (default), the function must return a Promise that resolves with the transformed result.
+If the option `sync` is `true`, though, `transform` should be a synchronous function which returns the transformed result.
 
 The reason you might use this option instead of simply applying your transform function some other way is that *the transformed result will be cached*. If your transformation involves additional filesystem I/O or other potentially slow processing, you can use this option to avoid repeating those steps every time a given configuration is loaded.
+
+##### configPath
+
+Type: `string`
+
+If provided, cosmiconfig will load and parse a config from this path, and will not perform its usual search.
 
 ### Instance methods (on `explorer`)
 
@@ -217,7 +235,7 @@ Performs both `clearFileCache()` and `clearDirectoryCache()`.
 - Built-in support for JSON, YAML, and CommonJS formats.
 - Stops at the first configuration found, instead of finding all that can be found down the filetree and merging them automatically.
 - Options.
-- Asynchronicity.
+- Asynchronous by default (though can be run synchronously).
 
 ## Contributing & Development
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = function (moduleName, options) {
     rcStrictJson: false,
     stopDir: oshomedir(),
     cache: true,
+    sync: false,
   }, options);
 
   if (options.argv && parsedCliArgs[options.argv]) {

--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -10,10 +10,11 @@ var funcRunner = require('./funcRunner');
 
 module.exports = function (options) {
   // When `options.sync` is `false` (default),
-// these cache Promises that resolve with results, not the results themselves.
+  // these cache Promises that resolve with results, not the results themselves.
   var fileCache = (options.cache) ? new Map() : null;
   var directoryCache = (options.cache) ? new Map() : null;
-  var transform = options.transform || (options.sync) ? identitySync : identityPromise;
+  var defaultTransform = options.sync ? identitySync : identityPromise;
+  var transform = options.transform || defaultTransform;
 
   function clearFileCache() {
     if (fileCache) fileCache.clear();

--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -6,12 +6,14 @@ var loadPackageProp = require('./loadPackageProp');
 var loadRc = require('./loadRc');
 var loadJs = require('./loadJs');
 var loadDefinedFile = require('./loadDefinedFile');
+var funcRunner = require('./funcRunner');
 
 module.exports = function (options) {
-  // These cache Promises that resolve with results, not the results themselves
+  // When `options.sync` is `false` (default),
+// these cache Promises that resolve with results, not the results themselves.
   var fileCache = (options.cache) ? new Map() : null;
   var directoryCache = (options.cache) ? new Map() : null;
-  var transform = options.transform || identityPromise;
+  var transform = options.transform || (options.sync) ? identitySync : identityPromise;
 
   function clearFileCache() {
     if (fileCache) fileCache.clear();
@@ -36,23 +38,31 @@ module.exports = function (options) {
       if (fileCache && fileCache.has(absoluteConfigPath)) {
         return fileCache.get(absoluteConfigPath);
       }
-      var result = loadDefinedFile(absoluteConfigPath, options)
-        .then(transform);
+      var result = (!options.sync)
+        ? loadDefinedFile(absoluteConfigPath, options)
+          .then(transform)
+        :  transform(loadDefinedFile(absoluteConfigPath, options));
       if (fileCache) fileCache.set(absoluteConfigPath, result);
       return result;
     }
 
-    if (!searchPath) return Promise.resolve(null);
+    if (!searchPath) return (!options.sync) ? Promise.resolve(null) : null;
 
     var absoluteSearchPath = path.resolve(process.cwd(), searchPath);
 
-    return isDirectory(absoluteSearchPath)
-      .then(function (searchPathIsDirectory) {
-        var directory = (searchPathIsDirectory)
+    return (!options.sync)
+      ? isDirectory(absoluteSearchPath)
+        .then(function (searchPathIsDirectory) {
+          var directory = (searchPathIsDirectory)
+            ? absoluteSearchPath
+            : path.dirname(absoluteSearchPath);
+          return searchDirectory(directory);
+        })
+      : searchDirectory(
+        isDir.sync(absoluteSearchPath)
           ? absoluteSearchPath
-          : path.dirname(absoluteSearchPath);
-        return searchDirectory(directory);
-      });
+          : path.dirname(absoluteSearchPath)
+      );
   }
 
   function searchDirectory(directory) {
@@ -60,32 +70,36 @@ module.exports = function (options) {
       return directoryCache.get(directory);
     }
 
-    var result = Promise.resolve()
-      .then(function () {
-        if (!options.packageProp) return;
-        return loadPackageProp(directory, options);
-      })
-      .then(function (result) {
-        if (result || !options.rc) return result;
-        return loadRc(path.join(directory, options.rc), options);
-      })
-      .then(function (result) {
-        if (result || !options.js) return result;
-        return loadJs(path.join(directory, options.js));
-      })
-      .then(function (result) {
-        if (result) return result;
+    var result = funcRunner(
+      !options.sync ? Promise.resolve() : undefined,
+      [
+        function () {
+          if (!options.packageProp) return;
+          return loadPackageProp(directory, options);
+        },
+        function (result) {
+          if (result || !options.rc) return result;
+          return loadRc(path.join(directory, options.rc), options);
+        },
+        function (result) {
+          if (result || !options.js) return result;
+          return loadJs(path.join(directory, options.js), options);
+        },
+        function (result) {
+          if (result) return result;
 
-        var splitPath = directory.split(path.sep);
-        var nextDirectory = (splitPath.length > 1)
-          ? splitPath.slice(0, -1).join(path.sep)
-          : null;
+          var splitPath = directory.split(path.sep);
+          var nextDirectory = (splitPath.length > 1)
+            ? splitPath.slice(0, -1).join(path.sep)
+            : null;
 
-        if (!nextDirectory || directory === options.stopDir) return null;
+          if (!nextDirectory || directory === options.stopDir) return null;
 
-        return searchDirectory(nextDirectory);
-      })
-      .then(transform);
+          return searchDirectory(nextDirectory);
+        },
+        transform,
+      ]
+    );
 
     if (directoryCache) directoryCache.set(directory, result);
     return result;
@@ -110,4 +124,8 @@ function isDirectory(filepath) {
 
 function identityPromise(x) {
   return Promise.resolve(x);
+}
+
+function identitySync(x) {
+  return x;
 }

--- a/lib/funcRunner.js
+++ b/lib/funcRunner.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var isPromise = require('is-promise');
+
+/**
+ * Runs the given functions sequentially. If the `init` param is a promise,
+ * functions are chained using `p.then()`. Otherwise, functions are chained by passing
+ * the result of each function to the next.
+ *
+ * @param {Promise | void} init
+ * @param {Array<Function>} funcs
+ * @returns {Promise<*> | *} - A promise if `init` was one, otherwise result of function
+ * chain execution.
+ */
+module.exports = function funcRunner(init, funcs) {
+  var isAsync = isPromise(init);
+
+  var result = init;
+  funcs.forEach(function (func) {
+    if (isAsync === true) {
+      result = result.then(func);
+    } else {
+      result = func(result);
+    }
+  });
+
+  return result;
+};

--- a/lib/loadDefinedFile.js
+++ b/lib/loadDefinedFile.js
@@ -6,7 +6,7 @@ var readFile = require('./readFile');
 var parseJson = require('./parseJson');
 
 module.exports = function (filepath, options) {
-  return readFile(filepath, { throwNotFound: true }).then(function (content) {
+  function parseContent(content) {
     var parsedConfig = (function () {
       switch (options.format) {
         case 'json':
@@ -32,7 +32,12 @@ module.exports = function (filepath, options) {
       config: parsedConfig,
       filepath: filepath,
     };
-  });
+  }
+
+  return (!options.sync)
+    ? readFile(filepath, { throwNotFound: true })
+      .then(parseContent)
+    : parseContent(readFile.sync(filepath, { throwNotFound: true }));
 };
 
 function tryAllParsing(content, filepath) {

--- a/lib/loadJs.js
+++ b/lib/loadJs.js
@@ -3,13 +3,17 @@
 var requireFromString = require('require-from-string');
 var readFile = require('./readFile');
 
-module.exports = function (filepath) {
-  return readFile(filepath).then(function (content) {
+module.exports = function (filepath, options) {
+  function parseJsFile(content) {
     if (!content) return null;
 
     return {
       config: requireFromString(content, filepath),
       filepath: filepath,
     };
-  });
+  }
+
+  return (!options.sync)
+    ? readFile(filepath).then(parseJsFile)
+    : parseJsFile(readFile.sync(filepath));
 };

--- a/lib/loadPackageProp.js
+++ b/lib/loadPackageProp.js
@@ -7,7 +7,7 @@ var parseJson = require('./parseJson');
 module.exports = function (packageDir, options) {
   var packagePath = path.join(packageDir, 'package.json');
 
-  return readFile(packagePath).then(function (content) {
+  function parseContent(content) {
     if (!content) return null;
     var parsedContent = parseJson(content, packagePath);
     var packagePropValue = parsedContent[options.packageProp];
@@ -17,5 +17,9 @@ module.exports = function (packageDir, options) {
       config: packagePropValue,
       filepath: packagePath,
     };
-  });
+  }
+
+  return (!options.sync)
+    ? readFile(packagePath).then(parseContent)
+    : parseContent(readFile.sync(packagePath));
 };

--- a/lib/loadRc.js
+++ b/lib/loadRc.js
@@ -4,16 +4,21 @@ var yaml = require('js-yaml');
 var requireFromString = require('require-from-string');
 var readFile = require('./readFile');
 var parseJson = require('./parseJson');
+var funcRunner = require('./funcRunner');
 
 module.exports = function (filepath, options) {
-  return loadExtensionlessRc().then(function (result) {
+  function afterLoadExtensionlessRc(result) {
     if (result) return result;
     if (options.rcExtensions) return loadRcWithExtensions();
     return null;
-  });
+  }
+
+  return (!options.sync)
+    ? loadExtensionlessRc().then(afterLoadExtensionlessRc)
+    : afterLoadExtensionlessRc(loadExtensionlessRc());
 
   function loadExtensionlessRc() {
-    return readRcFile().then(function (content) {
+    function parseExtensionlessRcFile(content) {
       if (!content) return null;
 
       var pasedConfig = (options.rcStrictJson)
@@ -25,11 +30,15 @@ module.exports = function (filepath, options) {
         config: pasedConfig,
         filepath: filepath,
       };
-    });
+    }
+
+    return (!options.sync)
+      ? readRcFile().then(parseExtensionlessRcFile)
+      : parseExtensionlessRcFile(readRcFile());
   }
 
   function loadRcWithExtensions() {
-    return readRcFile('json').then(function (content) {
+    function parseJsonRcFile(content) {
       if (content) {
         var successFilepath = filepath + '.json';
         return {
@@ -40,7 +49,9 @@ module.exports = function (filepath, options) {
       // If not content was found in the file with extension,
       // try the next possible extension
       return readRcFile('yaml');
-    }).then(function (content) {
+    }
+
+    function parseYmlRcFile(content) {
       if (content) {
         // If the previous check returned an object with a config
         // property, then it succeeded and this step can be skipped
@@ -53,7 +64,9 @@ module.exports = function (filepath, options) {
         };
       }
       return readRcFile('yml');
-    }).then(function (content) {
+    }
+
+    function parseYamlRcFile(content) {
       if (content) {
         if (content.config) return content;
         var successFilepath = filepath + '.yml';
@@ -63,7 +76,9 @@ module.exports = function (filepath, options) {
         };
       }
       return readRcFile('js');
-    }).then(function (content) {
+    }
+
+    function parseJsRcFile(content) {
       if (content) {
         if (content.config) return content;
         var successFilepath = filepath + '.js';
@@ -73,13 +88,20 @@ module.exports = function (filepath, options) {
         };
       }
       return null;
-    });
+    }
+
+    return funcRunner(
+      readRcFile('json'),
+      [parseJsonRcFile, parseYmlRcFile, parseYamlRcFile, parseJsRcFile]
+    );
   }
 
   function readRcFile(extension) {
     var filepathWithExtension = (extension)
       ? filepath + '.' + extension
       : filepath;
-    return readFile(filepathWithExtension);
+    return (!options.sync)
+      ? readFile(filepathWithExtension)
+      : readFile.sync(filepathWithExtension);
   }
 };

--- a/lib/readFile.js
+++ b/lib/readFile.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 
-module.exports = function (filepath, options) {
+function readFile(filepath, options) {
   options = options || {};
   options.throwNotFound = options.throwNotFound || false;
 
@@ -17,4 +17,21 @@ module.exports = function (filepath, options) {
       resolve(content);
     });
   });
+}
+
+readFile.sync = function readFileSync(filepath, options) {
+  options = options || {};
+  options.throwNotFound = options.throwNotFound || false;
+
+  try {
+    return fs.readFileSync(filepath, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT' && !options.throwNotFound) {
+      return null;
+    }
+    throw err;
+  }
 };
+
+module.exports = readFile;
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "author": "David Clark <david.dave.clark@gmail.com>",
   "contributors": [
-    "Bogdan Chadkin <trysound@yandex.ru>"
+    "Bogdan Chadkin <trysound@yandex.ru>",
+    "Suhas Karanth <sudo.suhas@gmail.com>"
   ],
   "license": "MIT",
   "bugs": {
@@ -33,24 +34,25 @@
   "homepage": "https://github.com/davidtheclark/cosmiconfig#readme",
   "dependencies": {
     "is-directory": "^0.3.1",
-    "js-yaml": "^3.4.3",
+    "is-promise": "^2.1.0",
+    "js-yaml": "^3.9.0",
     "minimist": "^1.2.0",
-    "object-assign": "^4.1.0",
+    "object-assign": "^4.1.1",
     "os-homedir": "^1.0.1",
     "parse-json": "^2.2.0",
     "require-from-string": "^1.1.0"
   },
   "devDependencies": {
-    "eslint": "^3.13.0",
+    "eslint": "^4.2.0",
     "eslint-config-davidtheclark-node": "^0.2.0",
     "eslint-plugin-node": "^3.0.5",
     "expect": "^1.20.2",
     "lodash": "^4.17.4",
-    "node-version-check": "^2.1.1",
-    "nyc": "^10.0.0",
-    "sinon": "^1.17.7",
+    "node-version-check": "^2.2.0",
+    "nyc": "^11.0.3",
+    "sinon": "^2.3.8",
     "tap-spec": "^4.1.1",
-    "tape": "^4.6.3"
+    "tape": "^4.7.0"
   },
   "engines": {
     "node": ">=0.12"

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -2,15 +2,13 @@
 
 var test = require('tape');
 var sinon = require('sinon');
-var path = require('path');
 var fs = require('fs');
 var cosmiconfig = require('..');
 var assertSearchSequence = require('./assertSearchSequence');
 var makeReadFileSyncStub = require('./makeReadFileSyncStub');
+var util = require('./util');
 
-function absolutePath(str) {
-  return path.join(__dirname, str);
-}
+var absolutePath = util.absolutePath;
 
 var cachedLoadConfig;
 var cachedLoadConfigSync;

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -6,13 +6,16 @@ var path = require('path');
 var fs = require('fs');
 var _ = require('lodash');
 var cosmiconfig = require('..');
+var makeReadFileSyncStub = require('./makeReadFileSyncStub');
 
 function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
 var statStub;
+var statSyncStub;
 var readFileStub;
+var readFileSyncStub;
 
 function setup() {
   statStub = sinon.stub(fs, 'stat').yieldsAsync(null, {
@@ -20,18 +23,28 @@ function setup() {
       return true;
     },
   });
+
+  statSyncStub = sinon.stub(fs, 'statSync').callsFake(function () {
+    return {
+      isDirectory: function () {
+        return true;
+      },
+    };
+  });
 }
 
 function teardown(assert, err) {
   if (readFileStub.restore) readFileStub.restore();
+  if (readFileSyncStub.restore) readFileSyncStub.restore();
   if (statStub.restore) statStub.restore();
+  if (statSyncStub.restore) statSyncStub.restore();
   assert.end(err);
 }
 
 test('do not find file, and give up', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
       case absolutePath('a/b/.foorc'):
@@ -47,13 +60,11 @@ test('do not find file, and give up', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
-  var loadConfig = cosmiconfig('foo', {
-    stopDir: absolutePath('.'),
-  }).load;
-
-  loadConfig(startDir).then(function (result) {
+  function doAsserts(result, readFileStub, statStub) { // intentional shadowing
     assert.equal(statStub.callCount, 1);
     assert.equal(_.get(statStub.getCall(0), 'args[0]'), absolutePath('a/b'));
 
@@ -77,16 +88,34 @@ test('do not find file, and give up', function (assert) {
     assert.equal(_.get(readFileStub.getCall(8), 'args[0]'), absolutePath('./foo.config.js'),
       'third and last dir: /foo.config.js');
     assert.equal(result, null);
-    teardown(assert);
-  }).catch(function (err) {
+  }
+
+  var loadConfig = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+  }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    sync: true,
+  }).load;
+
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub, statSyncStub);
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub, statStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('stop at stopDir, and give up', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
       case absolutePath('a/b/.foorc'):
@@ -102,37 +131,53 @@ test('stop at stopDir, and give up', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(result, stub) {
+    assert.equal(stub.callCount, 6);
+    assert.equal(_.get(stub.getCall(0), 'args[0]'), absolutePath('a/b/package.json'),
+      'first dir: a/b/package.json');
+    assert.equal(_.get(stub.getCall(1), 'args[0]'), absolutePath('a/b/.foorc'),
+      'first dir: a/b/.foorc');
+    assert.equal(_.get(stub.getCall(2), 'args[0]'), absolutePath('a/b/foo.config.js'),
+      'first dir: a/b/foo.config.js');
+    assert.equal(_.get(stub.getCall(3), 'args[0]'), absolutePath('a/package.json'),
+      'second and stopDir: a/package.json');
+    assert.equal(_.get(stub.getCall(4), 'args[0]'), absolutePath('a/.foorc'),
+      'second and stopDir: a/.foorc');
+    assert.equal(_.get(stub.getCall(5), 'args[0]'), absolutePath('a/foo.config.js'),
+      'second and stopDir: a/foo.config.js');
+    assert.equal(result, null);
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    sync: true,
+  }).load;
 
-  loadConfig(startDir).then(function (result) {
-    assert.equal(readFileStub.callCount, 6);
-    assert.equal(_.get(readFileStub.getCall(0), 'args[0]'), absolutePath('a/b/package.json'),
-      'first dir: a/b/package.json');
-    assert.equal(_.get(readFileStub.getCall(1), 'args[0]'), absolutePath('a/b/.foorc'),
-      'first dir: a/b/.foorc');
-    assert.equal(_.get(readFileStub.getCall(2), 'args[0]'), absolutePath('a/b/foo.config.js'),
-      'first dir: a/b/foo.config.js');
-    assert.equal(_.get(readFileStub.getCall(3), 'args[0]'), absolutePath('a/package.json'),
-      'second and stopDir: a/package.json');
-    assert.equal(_.get(readFileStub.getCall(4), 'args[0]'), absolutePath('a/.foorc'),
-      'second and stopDir: a/.foorc');
-    assert.equal(_.get(readFileStub.getCall(5), 'args[0]'), absolutePath('a/foo.config.js'),
-      'second and stopDir: a/foo.config.js');
-    assert.equal(result, null);
-    teardown(assert);
-  }).catch(function (err) {
+  try {
+    var result = loadConfigSync(startDir);
+    doAsserts(result, readFileSyncStub, statSyncStub);
+    loadConfig(startDir).then(function (result) {
+      doAsserts(result, readFileStub, statStub);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });
 
 test('find invalid YAML in rc file', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
         callback({ code: 'ENOENT' });
@@ -143,15 +188,31 @@ test('find invalid YAML in rc file', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -161,7 +222,7 @@ test('find invalid YAML in rc file', function (assert) {
 test('find invalid JSON in rc file with rcStrictJson', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
         callback({ code: 'ENOENT' });
@@ -172,16 +233,33 @@ test('find invalid JSON in rc file with rcStrictJson', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
     rcStrictJson: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    rcStrictJson: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -191,7 +269,7 @@ test('find invalid JSON in rc file with rcStrictJson', function (assert) {
 test('find invalid package.json', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
         callback(null, '{ "foo": "bar", }');
@@ -199,15 +277,31 @@ test('find invalid package.json', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -217,7 +311,7 @@ test('find invalid package.json', function (assert) {
 test('find invalid JS in .config.js file', function (assert) {
   setup();
   var startDir = absolutePath('a/b');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/package.json'):
       case absolutePath('a/b/.foorc'):
@@ -229,15 +323,31 @@ test('find invalid JS in .config.js file', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'SyntaxError', 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('a'),
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('a'),
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'SyntaxError', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -247,7 +357,7 @@ test('find invalid JS in .config.js file', function (assert) {
 test('with rcExtensions, find invalid JSON in .foorc.json', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -259,16 +369,33 @@ test('with rcExtensions, find invalid JSON in .foorc.json', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -278,7 +405,7 @@ test('with rcExtensions, find invalid JSON in .foorc.json', function (assert) {
 test('with rcExtensions, find invalid YAML in .foorc.yaml', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -291,16 +418,32 @@ test('with rcExtensions, find invalid YAML in .foorc.yaml', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
 
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+  }
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -310,7 +453,7 @@ test('with rcExtensions, find invalid YAML in .foorc.yaml', function (assert) {
 test('with rcExtensions, find invalid YAML in .foorc.yml', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -324,16 +467,33 @@ test('with rcExtensions, find invalid YAML in .foorc.yml', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'YAMLException', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   }).catch(function (err) {
     teardown(assert, err);
@@ -343,7 +503,7 @@ test('with rcExtensions, find invalid YAML in .foorc.yml', function (assert) {
 test('with rcExtensions, find invalid JS in .foorc.js', function (assert) {
   setup();
   var startDir = absolutePath('a/b/c/d/e/f');
-  readFileStub = sinon.stub(fs, 'readFile', function (searchPath, encoding, callback) {
+  function readFile(searchPath, encoding, callback) {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
       case absolutePath('a/b/c/d/e/f/.foorc'):
@@ -358,19 +518,37 @@ test('with rcExtensions, find invalid JS in .foorc.js', function (assert) {
       default:
         callback(new Error('irrelevant path ' + searchPath));
     }
-  });
+  }
+  readFileStub = sinon.stub(fs, 'readFile').callsFake(readFile);
+  readFileSyncStub = makeReadFileSyncStub(readFile);
+
+  function doAsserts(error) {
+    assert.ok(error, 'threw error');
+    assert.equal(error.name, 'SyntaxError', 'threw correct error type');
+  }
 
   var loadConfig = cosmiconfig('foo', {
     stopDir: absolutePath('.'),
     rcExtensions: true,
   }).load;
+  var loadConfigSync = cosmiconfig('foo', {
+    stopDir: absolutePath('.'),
+    rcExtensions: true,
+    sync: true,
+  }).load;
+
+  try {
+    loadConfigSync(startDir);
+    assert.fail('should have errored');
+  } catch (err) {
+    doAsserts(err);
+  }
 
   loadConfig(startDir).then(function () {
     assert.fail('should have errored');
     teardown(assert);
   }).catch(function (error) {
-    assert.ok(error, 'threw error');
-    assert.equal(error.name, 'SyntaxError', 'threw correct error type');
+    doAsserts(error);
     teardown(assert);
   });
 });
@@ -378,10 +556,19 @@ test('with rcExtensions, find invalid JS in .foorc.js', function (assert) {
 test('Configuration file not exist', function (assert) {
   setup();
   var loadConfig = cosmiconfig('not_exist_rc_name').load;
-  loadConfig('.').then(function (result) {
+  var loadConfigSync = cosmiconfig('not_exist_rc_name', { sync: true }).load;
+
+  try {
+    var result = loadConfigSync('.');
     assert.equal(result, null);
-    teardown(assert);
-  }).catch(function (err) {
+
+    loadConfig('.').then(function (result) {
+      assert.equal(result, null);
+      teardown(assert);
+    }).catch(function (err) {
+      teardown(assert, err);
+    });
+  } catch (err) {
     teardown(assert, err);
-  });
+  }
 });

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -2,15 +2,13 @@
 
 var test = require('tape');
 var sinon = require('sinon');
-var path = require('path');
 var fs = require('fs');
 var _ = require('lodash');
 var cosmiconfig = require('..');
 var makeReadFileSyncStub = require('./makeReadFileSyncStub');
+var util = require('./util');
 
-function absolutePath(str) {
-  return path.join(__dirname, str);
-}
+var absolutePath = util.absolutePath;
 
 var statStub;
 var statSyncStub;

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -8,13 +8,22 @@ function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
+function failAssert(assert) {
+  assert.fail('should have errored');
+  assert.end();
+}
+
 test('defined file that does not exist', function (assert) {
   var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('does/not/exist'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+  var loadConfigSync = cosmiconfig(null, { sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('does/not/exist'));
+    failAssert(assert);
+  } catch (error) {
+    assert.equal(error.code, 'ENOENT', 'with expected format');
+  }
+  return loadConfig(null, absolutePath('does/not/exist'))
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.equal(error.code, 'ENOENT', 'with expected format');
       assert.end();
@@ -23,11 +32,15 @@ test('defined file that does not exist', function (assert) {
 
 test('defined JSON file with syntax error, without expected format', function (assert) {
   var loadConfig = cosmiconfig().load;
+  var loadConfigSync = cosmiconfig(null, { sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.json'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(/^Failed to parse/.test(error.message));
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.json'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(/^Failed to parse/.test(error.message));
       assert.end();
@@ -35,14 +48,16 @@ test('defined JSON file with syntax error, without expected format', function (a
 });
 
 test('defined JSON file with syntax error, with expected format', function (assert) {
-  var loadConfig = cosmiconfig(null, {
-    format: 'json',
-  }).load;
+  var loadConfig = cosmiconfig(null, { format: 'json' }).load;
+  var loadConfigSync = cosmiconfig(null, { format: 'json', sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.json'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.json'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(/JSON Error/.test(error.message), 'threw correct error type');
       assert.end();
@@ -51,11 +66,15 @@ test('defined JSON file with syntax error, with expected format', function (asse
 
 test('defined YAML file with syntax error, without expected format', function (assert) {
   var loadConfig = cosmiconfig().load;
+  var loadConfigSync = cosmiconfig(null, { sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.yaml'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(/^Failed to parse/.test(error.message));
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.yaml'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(/^Failed to parse/.test(error.message));
       assert.end();
@@ -63,14 +82,16 @@ test('defined YAML file with syntax error, without expected format', function (a
 });
 
 test('defined YAML file with syntax error, with expected format', function (assert) {
-  var loadConfig = cosmiconfig(null, {
-    format: 'yaml',
-  }).load;
+  var loadConfig = cosmiconfig(null, { format: 'yaml' }).load;
+  var loadConfigSync = cosmiconfig(null, { format: 'yaml', sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.yaml'));
+    failAssert(assert);
+  } catch (error) {
+    assert.equal(error.name, 'YAMLException');
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.yaml'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.equal(error.name, 'YAMLException');
       assert.end();
@@ -79,11 +100,15 @@ test('defined YAML file with syntax error, with expected format', function (asse
 
 test('defined JS file with syntax error, without expected format', function (assert) {
   var loadConfig = cosmiconfig().load;
+  var loadConfigSync = cosmiconfig(null, { sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.js'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(/^Failed to parse/.test(error.message));
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.js'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(/^Failed to parse/.test(error.message));
       assert.end();
@@ -91,14 +116,16 @@ test('defined JS file with syntax error, without expected format', function (ass
 });
 
 test('defined JS file with syntax error, with expected format', function (assert) {
-  var loadConfig = cosmiconfig(null, {
-    format: 'js',
-  }).load;
+  var loadConfig = cosmiconfig(null, { format: 'js' }).load;
+  var loadConfigSync = cosmiconfig(null, { format: 'js', sync: true }).load;
+  try {
+    loadConfigSync(null, absolutePath('fixtures/foo-invalid.js'));
+    failAssert(assert);
+  } catch (error) {
+    assert.ok(!/^Failed to parse/.test(error.message));
+  }
   return loadConfig(null, absolutePath('fixtures/foo-invalid.js'))
-    .then(function () {
-      assert.fail('should have errored');
-      assert.end();
-    })
+    .then(failAssert.bind(null, assert))
     .catch(function (error) {
       assert.ok(!/^Failed to parse/.test(error.message));
       assert.end();

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -1,12 +1,10 @@
 'use strict';
 
 var test = require('tape');
-var path = require('path');
 var cosmiconfig = require('..');
+var util = require('./util');
 
-function absolutePath(str) {
-  return path.join(__dirname, str);
-}
+var absolutePath = util.absolutePath;
 
 function failAssert(assert) {
   assert.fail('should have errored');

--- a/test/funcRunner.test.js
+++ b/test/funcRunner.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+var test = require('tape');
+var sinon = require('sinon');
+var isPromise = require('is-promise');
+
+var funcRunner = require('../lib/funcRunner');
+
+function getFuncStub() {
+  return sinon.stub().returns('some-value');
+}
+
+test('if isPromise(init), returns a promise', function (assert) {
+  var init = Promise.resolve(1);
+  var res = funcRunner(init, []);
+
+  assert.true(isPromise(res), 'funcRunner returns a promise');
+  assert.end();
+});
+
+test('if !isPromise(init), does not return a promise', function (assert) {
+  var init = 1;
+  var res = funcRunner(init, []);
+
+  assert.true(!isPromise(res), 'funcRunner does not return a promise');
+  assert.end();
+});
+
+test('if isPromise(init), calls funcs with .then', function (assert) {
+  var init = Promise.resolve(1);
+  var funcStub = getFuncStub();
+  var pSpy = sinon.spy(init, 'then');
+
+  var res = funcRunner(init, [funcStub]);
+
+  assert.true(pSpy.calledOnce, 'init.then was called once');
+  assert.true(pSpy.firstCall.calledWith(funcStub), 'init.then was called with given func');
+
+  function teardown(assert, err) {
+    pSpy.restore();
+    assert.end(err);
+  }
+
+  res.then(function (val) {
+    assert.equal(val, 'some-value', 'Resolved result matches expected');
+
+    assert.true(funcStub.calledOnce, 'given func was called once');
+    assert.true(funcStub.calledWith(1), 'given func was called with init\'s resolved value');
+
+    teardown(assert);
+  }).catch(function (err) {
+    teardown(assert, err);
+  });
+});
+
+test('if !isPromise(init), calls funcs in sync', function (assert) {
+  var init = 1;
+  var funcStub = getFuncStub();
+  var res = funcRunner(init, [funcStub]);
+
+  assert.equal(res, 'some-value', 'Returned result matches expected');
+  assert.true(funcStub.calledOnce, 'given func was called once');
+  assert.true(funcStub.calledWith(1), 'given func was called with init\'s value');
+
+  assert.end();
+});
+
+test(
+  'if isPromise(init), chains function calls with .then',
+  function (assert) {
+    var init = Promise.resolve(1);
+    var taskRes = Promise.resolve('blistering barnacles!');
+    // var pSpy = sinon.spy(taskRes, 'then');
+    function task(val) {
+      assert.equal(val, 1, 'task func called with init\'s resolved value');
+      return taskRes;
+    }
+    var funcStub = getFuncStub();
+
+    var res = funcRunner(init, [task, funcStub]);
+
+    res.then(function () {
+      // This test fails on node <= 4 for some reason
+      // assert.true(pSpy.calledOnce, 'taskRes.then was called once');
+      assert.true(funcStub.calledOnce, 'chained func was called once');
+      assert.true(
+        funcStub.calledWith('blistering barnacles!'),
+        'chained func was called with taskRes\'s resolved value'
+      );
+      assert.end();
+    });
+  }
+);
+
+test('if !isPromise(init), chains function calls', function (assert) {
+  var init = 1;
+  function task(val) {
+    assert.equal(val, 1, 'task func called with init\'s value');
+    return 'blistering barnacles!';
+  }
+  var funcStub = getFuncStub();
+
+  funcRunner(init, [task, funcStub]);
+
+  assert.true(funcStub.calledOnce, 'chained func was called once');
+  assert.true(
+    funcStub.calledWith('blistering barnacles!'),
+    'chained func was called with task func\'s returned value'
+  );
+  assert.end();
+});

--- a/test/makeReadFileSyncStub.js
+++ b/test/makeReadFileSyncStub.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var fs = require('fs');
+
+var sinon = require('sinon');
+
+module.exports = function makeReadFileSyncStub(readFile) {
+  return sinon.stub(fs, 'readFileSync').callsFake(
+    function readFileSync(search, encoding) {
+      var errSync, contentsSync;
+
+      readFile(search, encoding, function (err, contents) {
+        errSync = err;
+        contentsSync = contents;
+      });
+
+      if (errSync) throw errSync;
+
+      return contentsSync;
+    }
+  );
+};

--- a/test/successful-directories.test.js
+++ b/test/successful-directories.test.js
@@ -2,15 +2,13 @@
 
 var test = require('tape');
 var sinon = require('sinon');
-var path = require('path');
 var fs = require('fs');
 var cosmiconfig = require('..');
 var assertSearchSequence = require('./assertSearchSequence');
 var makeReadFileSyncStub = require('./makeReadFileSyncStub');
+var util = require('./util');
 
-function absolutePath(str) {
-  return path.join(__dirname, str);
-}
+var absolutePath = util.absolutePath;
 
 var statStub;
 var statSyncStub;

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -8,54 +8,38 @@ function absolutePath(str) {
   return path.join(__dirname, str);
 }
 
-test('defined JSON config path', function (assert) {
-  var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('fixtures/foo.json')).then(function (result) {
-    assert.deepEqual(result.config, {
-      foo: true,
-    });
-    assert.equal(result.filepath, absolutePath('fixtures/foo.json'));
-    assert.end();
-  }).catch(function (err) {
-    assert.end(err);
+function doAsserts(assert, result, filePath) {
+  assert.deepEqual(result.config, {
+    foo: true,
   });
-});
+  assert.equal(result.filepath, filePath);
+}
 
-test('defined YAML config path', function (assert) {
-  var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('fixtures/foo.yaml')).then(function (result) {
-    assert.deepEqual(result.config, {
-      foo: true,
-    });
-    assert.equal(result.filepath, absolutePath('fixtures/foo.yaml'));
-    assert.end();
-  }).catch(function (err) {
-    assert.end(err);
-  });
-});
+function makeFileTest(file) {
+  var filePath = absolutePath(file);
+  return function fileTest(assert) {
+    var loadConfig = cosmiconfig().load;
+    var loadConfigSync = cosmiconfig(null, { sync: true }).load;
 
-test('defined JS config path', function (assert) {
-  var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('fixtures/foo.js')).then(function (result) {
-    assert.deepEqual(result.config, {
-      foo: true,
-    });
-    assert.equal(result.filepath, absolutePath('fixtures/foo.js'));
-    assert.end();
-  }).catch(function (err) {
-    assert.end(err);
-  });
-});
+    try {
+      var result = loadConfigSync(null, filePath);
+      doAsserts(assert, result, filePath);
+      loadConfig(null, absolutePath(file)).then(function (result) {
+        doAsserts(assert, result, filePath);
+        assert.end();
+      }).catch(function (err) {
+        assert.end(err);
+      });
+    } catch (err) {
+      assert.end(err);
+    }
+  };
+}
 
-test('defined modulized JS config path', function (assert) {
-  var loadConfig = cosmiconfig().load;
-  loadConfig(null, absolutePath('fixtures/foo-module.js')).then(function (result) {
-    assert.deepEqual(result.config, {
-      foo: true,
-    });
-    assert.equal(result.filepath, absolutePath('fixtures/foo-module.js'));
-    assert.end();
-  }).catch(function (err) {
-    assert.end(err);
-  });
-});
+test('defined JSON config path', makeFileTest('fixtures/foo.json'));
+
+test('defined YAML config path', makeFileTest('fixtures/foo.yaml'));
+
+test('defined JS config path', makeFileTest('fixtures/foo.js'));
+
+test('defined modulized JS config path', makeFileTest('fixtures/foo-module.js'));

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var path = require('path');
+
+exports.absolutePath = function absolutePath(str) {
+  return path.join(__dirname, str);
+};
+
+exports.failAssert = function failAssert(assert) {
+  assert.fail('should have errored');
+  assert.end();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,19 +12,28 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.1:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
+acorn@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
 
 ajv-keywords@^1.0.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.0.tgz#c11e6859eafff83e0dafc416929472eca946aa2c"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
 ajv@^4.7.0:
-  version "4.10.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.10.4.tgz#c0974dd00b3464984892d6010aa9c2c945933254"
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
     co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
+ajv@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
@@ -39,21 +48,33 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+ansi-escapes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
 ansi-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.0.0.tgz#c5061b6e0ef8a81775e50f5d66151bf6bf371107"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-append-transform@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.3.0.tgz#d6933ce4a85f09445d9ccc4cc119051b7381a813"
+ansi-styles@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
+  dependencies:
+    color-convert "^1.0.0"
+
+append-transform@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+  dependencies:
+    default-require-extensions "^1.0.0"
 
 archy@^1.0.0:
   version "1.0.0"
@@ -72,8 +93,8 @@ arr-diff@^2.0.0:
     arr-flatten "^1.0.1"
 
 arr-flatten@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -93,93 +114,90 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-async@^1.4.0, async@^1.4.2:
+async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@~0.2.6:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
-
-babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
+babel-code-frame@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
     chalk "^1.1.0"
     esutils "^2.0.2"
-    js-tokens "^2.0.0"
+    js-tokens "^3.0.0"
 
 babel-generator@^6.18.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.21.0.tgz#605f1269c489a1c75deeca7ea16d43d4656c8494"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.25.0.tgz#33a1af70d5f2890aeb465a4a7793c1df6a9ea9fc"
   dependencies:
-    babel-messages "^6.8.0"
-    babel-runtime "^6.20.0"
-    babel-types "^6.21.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.25.0"
     detect-indent "^4.0.0"
     jsesc "^1.3.0"
     lodash "^4.2.0"
     source-map "^0.5.0"
+    trim-right "^1.0.1"
 
-babel-messages@^6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.8.0.tgz#bf504736ca967e6d65ef0adb5a2a5f947c8e0eb9"
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
-    babel-runtime "^6.0.0"
+    babel-runtime "^6.22.0"
 
-babel-runtime@^6.0.0, babel-runtime@^6.20.0, babel-runtime@^6.9.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
+babel-runtime@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
 babel-template@^6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
   dependencies:
-    babel-runtime "^6.9.0"
-    babel-traverse "^6.16.0"
-    babel-types "^6.16.0"
-    babylon "^6.11.0"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.25.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
     lodash "^4.2.0"
 
-babel-traverse@^6.16.0, babel-traverse@^6.18.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.21.0.tgz#69c6365804f1a4f69eb1213f85b00a818b8c21ad"
+babel-traverse@^6.18.0, babel-traverse@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
-    babel-code-frame "^6.20.0"
-    babel-messages "^6.8.0"
-    babel-runtime "^6.20.0"
-    babel-types "^6.21.0"
-    babylon "^6.11.0"
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
     debug "^2.2.0"
     globals "^9.0.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.21.0.tgz#314b92168891ef6d3806b7f7a917fdf87c11a4b2"
+babel-types@^6.18.0, babel-types@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
-    babel-runtime "^6.20.0"
+    babel-runtime "^6.22.0"
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
+babylon@^6.17.2, babylon@^6.17.4:
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
-balanced-match@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-brace-expansion@^1.0.0:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
   dependencies:
-    balanced-match "^0.4.1"
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^1.8.2:
@@ -189,10 +207,6 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
-
-buffer-shims@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -224,6 +238,10 @@ camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
@@ -241,15 +259,23 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
-cli-cursor@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
-    restore-cursor "^1.0.1"
+    restore-cursor "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -279,6 +305,16 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+color-convert@^1.0.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -287,7 +323,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6:
+concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -296,8 +332,8 @@ concat-stream@^1.4.6:
     typedarray "^0.0.6"
 
 convert-source-map@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.3.0.tgz#e9f3e9c6e2728efc2676696a70eb382f73106a67"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
 core-js@^2.4.0:
   version "2.4.1"
@@ -307,28 +343,22 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-spawn@^4:
+cross-spawn@^4, cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-d@^0.1.1, d@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
-  dependencies:
-    es5-ext "~0.10.2"
-
 debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@^2.1.1, debug@^2.2.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
+debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
-    ms "0.7.2"
+    ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -377,9 +407,13 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-doctrine@^1.2.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+diff@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
+
+doctrine@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
@@ -389,14 +423,14 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 error-ex@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.0.tgz#e67b43f3e82c96ea3a584ffee0b9fc3325d802d9"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.5.0, es-abstract@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.6.1.tgz#bb8a2064120abcf928a086ea3d9043114285ec99"
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.0"
@@ -411,70 +445,9 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
-es5-ext@^0.10.7, es5-ext@^0.10.8, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
-  version "0.10.12"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.12.tgz#aa84641d4db76b62abba5e45fd805ecbab140047"
-  dependencies:
-    es6-iterator "2"
-    es6-symbol "~3.1"
-
-es6-iterator@2:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.0.tgz#bd968567d61635e33c0b80727613c9cb4b096bac"
-  dependencies:
-    d "^0.1.1"
-    es5-ext "^0.10.7"
-    es6-symbol "3"
-
-es6-map@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.4.tgz#a34b147be224773a4d7da8072794cefa3632b897"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
-    es6-iterator "2"
-    es6-set "~0.1.3"
-    es6-symbol "~3.1.0"
-    event-emitter "~0.3.4"
-
-es6-set@~0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.4.tgz#9516b6761c2964b92ff479456233a247dc707ce8"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
-    es6-iterator "2"
-    es6-symbol "3"
-    event-emitter "~0.3.4"
-
-es6-symbol@3, es6-symbol@~3.1, es6-symbol@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.0.tgz#94481c655e7a7cad82eba832d97d5433496d7ffa"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
-
-es6-weak-map@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.1.tgz#0d2bbd8827eb5fb4ba8f97fbfea50d43db21ea81"
-  dependencies:
-    d "^0.1.1"
-    es5-ext "^0.10.8"
-    es6-iterator "2"
-    es6-symbol "3"
-
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-
-escope@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
-  dependencies:
-    es6-map "^0.1.3"
-    es6-weak-map "^2.0.1"
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
 
 eslint-config-davidtheclark-node@^0.2.0:
   version "0.2.1"
@@ -490,85 +463,94 @@ eslint-plugin-node@^3.0.5:
     resolve "^1.1.7"
     semver "5.3.0"
 
-eslint@^3.13.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.13.0.tgz#636925fd163c9babe2e8be7ae43caf518d469577"
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
-    babel-code-frame "^6.16.0"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.2.0.tgz#a2b3184111b198e02e9c7f3cca625a5e01c56b3d"
+  dependencies:
+    ajv "^5.2.0"
+    babel-code-frame "^6.22.0"
     chalk "^1.1.3"
-    concat-stream "^1.4.6"
-    debug "^2.1.1"
-    doctrine "^1.2.2"
-    escope "^3.6.0"
-    espree "^3.3.1"
+    concat-stream "^1.6.0"
+    debug "^2.6.8"
+    doctrine "^2.0.0"
+    eslint-scope "^3.7.1"
+    espree "^3.4.3"
+    esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.14.0"
-    ignore "^3.2.0"
+    glob "^7.1.2"
+    globals "^9.17.0"
+    ignore "^3.3.3"
     imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
+    inquirer "^3.0.6"
     is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
+    js-yaml "^3.8.4"
+    json-stable-stringify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
+    path-is-inside "^1.0.2"
+    pluralize "^4.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
     strip-json-comments "~2.0.1"
-    table "^3.7.8"
+    table "^4.0.1"
     text-table "~0.2.0"
-    user-home "^2.0.0"
 
-espree@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.3.2.tgz#dbf3fadeb4ecb4d4778303e50103b3d36c88b89c"
+espree@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
   dependencies:
-    acorn "^4.0.1"
+    acorn "^5.0.1"
     acorn-jsx "^3.0.0"
 
-esprima@^2.6.0:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.1.0.tgz#4713b6536adf7f2ac4f327d559e7756bff648220"
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
   dependencies:
-    estraverse "~4.1.0"
+    estraverse "^4.1.0"
     object-assign "^4.0.1"
 
-estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
-
-estraverse@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-event-emitter@~0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.4.tgz#8d63ddfb4cfe1fae3b32ca265c4c720222080bb5"
+execa@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
   dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.7"
-
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+    cross-spawn "^4.0.0"
+    get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -594,22 +576,40 @@ expect@^1.20.2:
     object-keys "^1.0.9"
     tmatch "^2.0.1"
 
+external-editor@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
+  dependencies:
+    iconv-lite "^0.4.17"
+    jschardet "^1.4.2"
+    tmp "^0.0.31"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
   dependencies:
     is-extglob "^1.0.0"
 
+fast-deep-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-figures@^1.3.5, figures@^1.4.0:
+figures@^1.4.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
@@ -619,8 +619,8 @@ file-entry-cache@^2.0.0:
     object-assign "^4.0.1"
 
 filename-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.0.tgz#996e3e80479b98b9897f15a8a58b3d084e926775"
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -640,12 +640,18 @@ find-cache-dir@^0.1.1:
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
 
-find-up@^1.0.0, find-up@^1.1.2:
+find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
+
+find-up@^2.0.0, find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
 
 flat-cache@^1.2.1:
   version "1.2.2"
@@ -662,15 +668,15 @@ for-each@~0.3.2:
   dependencies:
     is-function "~1.0.0"
 
-for-in@^0.1.5:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.6.tgz#c9f96e89bfad18a545af5ec3ed352a1d9e5b4dc8"
+for-in@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
 for-own@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.4.tgz#0149b41a39088c7515f51ebe1c1386d45f935072"
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   dependencies:
-    for-in "^0.1.5"
+    for-in "^1.0.1"
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -683,11 +689,11 @@ foreground-child@^1.5.3, foreground-child@^1.5.6:
     cross-spawn "^4"
     signal-exit "^3.0.0"
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
-    samsam "~1.1"
+    samsam "1.x"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -697,19 +703,16 @@ function-bind@^1.0.2, function-bind@^1.1.0, function-bind@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-generate-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
-
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  dependencies:
-    is-property "^1.0.0"
-
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -724,20 +727,20 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@~7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.2, glob@~7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0, globals@^9.14.0:
-  version "9.14.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
+globals@^9.0.0, globals@^9.17.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -755,8 +758,8 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
 handlebars@^4.0.3:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.6.tgz#2ce4484850537f9c97a8026d5399b935c4ed4ed7"
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -774,6 +777,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 has@^1.0.1, has@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
@@ -781,12 +788,16 @@ has@^1.0.1, has@~1.0.1:
     function-bind "^1.0.2"
 
 hosted-git-info@^2.1.4:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-ignore@^3.0.11, ignore@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
+iconv-lite@^0.4.17:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
+
+ignore@^3.0.11, ignore@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -799,35 +810,28 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inherits@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
-
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+inquirer@^3.0.6:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.0.tgz#45b44c2160c729d7578c54060b3eed94487bb42b"
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    ansi-escapes "^2.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
     lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
-
-interpret@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -853,9 +857,9 @@ is-boolean-object@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
 
-is-buffer@^1.0.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
+is-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -876,8 +880,8 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-dotfile@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
 
 is-equal-shallow@^0.1.3:
   version "0.1.3"
@@ -886,20 +890,20 @@ is-equal-shallow@^0.1.3:
     is-primitive "^2.0.0"
 
 is-equal@^1.5.1:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/is-equal/-/is-equal-1.5.3.tgz#05b7fa3a1122cbc71c1ef41ce0142d5532013b29"
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/is-equal/-/is-equal-1.5.5.tgz#5e85f1957e052883247feb386965a3bba15fbb3d"
   dependencies:
     has "^1.0.1"
     is-arrow-function "^2.0.3"
     is-boolean-object "^1.0.0"
     is-callable "^1.1.3"
     is-date-object "^1.0.1"
-    is-generator-function "^1.0.3"
+    is-generator-function "^1.0.6"
     is-number-object "^1.0.3"
     is-regex "^1.0.3"
     is-string "^1.0.4"
     is-symbol "^1.0.1"
-    object.entries "^1.0.3"
+    object.entries "^1.0.4"
 
 is-extendable@^0.1.1:
   version "0.1.1"
@@ -929,7 +933,7 @@ is-function@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
-is-generator-function@^1.0.3:
+is-generator-function@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.6.tgz#9e71653cd15fff341c79c4151460a131d31e9fc4"
 
@@ -939,22 +943,19 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
-is-my-json-valid@^2.10.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz#936edda3ca3c211fd98f3b2d3e08da43f7b2915b"
-  dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
-
 is-number-object@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
 
-is-number@^2.0.2, is-number@^2.1.0:
+is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
 
@@ -976,25 +977,31 @@ is-path-inside@^1.0.0:
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
-  resolved "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
 
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
 is-regex@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.3.tgz#0d55182bddf9f2fde278220aec3a75642c908637"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
 
 is-resolvable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-string@^1.0.4:
   version "1.0.4"
@@ -1008,13 +1015,17 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isexe@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz#36f3e22e60750920f5e7241a476a8c6a42275ad0"
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -1022,70 +1033,77 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-istanbul-lib-coverage@^1.0.0, istanbul-lib-coverage@^1.0.0-alpha, istanbul-lib-coverage@^1.0.0-alpha.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz#c3f9b6d226da12424064cce87fce0fb57fdfa7a2"
+istanbul-lib-coverage@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
 
-istanbul-lib-hook@^1.0.0-alpha.4:
-  version "1.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.4.tgz#8c5bb9f6fbd8526e0ae6cf639af28266906b938f"
+istanbul-lib-hook@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz#dd6607f03076578fe7d6f2a630cf143b49bacddc"
   dependencies:
-    append-transform "^0.3.0"
+    append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.3.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.4.2.tgz#0e2fdfac93c1dabf2e31578637dc78a19089f43e"
+istanbul-lib-instrument@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz#e9fd920e4767f3d19edc765e2d6b3f5ccbd0eea8"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
-    babylon "^6.13.0"
-    istanbul-lib-coverage "^1.0.0"
+    babylon "^6.17.4"
+    istanbul-lib-coverage "^1.1.1"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.0.0-alpha.3:
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz#32d5f6ec7f33ca3a602209e278b2e6ff143498af"
+istanbul-lib-report@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#f0e55f56655ffa34222080b7a0cd4760e1405fc9"
   dependencies:
-    async "^1.4.2"
-    istanbul-lib-coverage "^1.0.0-alpha"
+    istanbul-lib-coverage "^1.1.1"
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
-    rimraf "^2.4.3"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.1.0.tgz#9d429218f35b823560ea300a96ff0c3bbdab785f"
+istanbul-lib-source-maps@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz#a6fe1acba8ce08eebc638e572e294d267008aa0c"
   dependencies:
-    istanbul-lib-coverage "^1.0.0-alpha.0"
+    debug "^2.6.3"
+    istanbul-lib-coverage "^1.1.1"
     mkdirp "^0.5.1"
-    rimraf "^2.4.4"
+    rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.0.0.tgz#24b4eb2b1d29d50f103b369bd422f6e640aa0777"
+istanbul-reports@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.1.tgz#042be5c89e175bc3f86523caab29c014e77fee4e"
   dependencies:
     handlebars "^4.0.3"
 
-js-tokens@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
+js-tokens@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.4.3, js-yaml@^3.5.1:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
+js-yaml@^3.8.4, js-yaml@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
   dependencies:
     argparse "^1.0.7"
-    esprima "^2.6.0"
+    esprima "^4.0.0"
+
+jschardet@^1.4.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.0.tgz#a61f310306a5a71188e1b1acd08add3cfbb08b1e"
 
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
-json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
+json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -1095,15 +1113,17 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-
 kind-of@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
-    is-buffer "^1.0.2"
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  dependencies:
+    is-buffer "^1.1.5"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -1132,6 +1152,22 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -1140,26 +1176,26 @@ lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
 loose-envify@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.0.tgz#6b26248c42f6d4fa4b0d8542f78edfcde35642a8"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
-    js-tokens "^2.0.0"
+    js-tokens "^3.0.0"
 
 lru-cache@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
-    pseudomap "^1.0.1"
-    yallist "^2.0.0"
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 md5-hex@^1.2.0:
   version "1.3.0"
@@ -1171,11 +1207,17 @@ md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
 
-merge-source-map@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.0.3.tgz#da1415f2722a5119db07b14c4f973410863a2abf"
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
-    source-map "^0.5.3"
+    mimic-fn "^1.0.0"
+
+merge-source-map@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.0.4.tgz#a5de46538dae84d4114cc5ea02b4772a6346701f"
+  dependencies:
+    source-map "^0.5.6"
 
 micromatch@^2.3.11:
   version "2.3.11"
@@ -1195,13 +1237,17 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-minimatch@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  dependencies:
-    brace-expansion "^1.0.0"
+mimic-fn@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-minimist@0.0.8, minimist@~0.0.1:
+minimatch@^3.0.2, minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
@@ -1209,33 +1255,41 @@ minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+
 mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-node-version-check@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/node-version-check/-/node-version-check-2.1.1.tgz#d8b47cffc92b8ea0731ee8a69fc6410fd3ec5caf"
+node-version-check@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-version-check/-/node-version-check-2.2.0.tgz#929ce106555d0f427f8e7f0ffecedb7cab79624b"
   dependencies:
-    semver "^5.2.0"
+    semver "^5.3.0"
 
 normalize-package-data@^2.3.2:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.5.tgz#8d924f142960e1777e7ffe170543631cc7cb02df"
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
     hosted-git-info "^2.1.4"
     is-builtin-module "^1.0.0"
@@ -1243,16 +1297,24 @@ normalize-package-data@^2.3.2:
     validate-npm-package-license "^3.0.1"
 
 normalize-path@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nyc@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-10.0.0.tgz#95bd4a2c3487f33e1e78f213c6d5a53d88074ce6"
+nyc@^11.0.3:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.1.0.tgz#d6b3c5e16892a25af63138ba484676aa8a22eda7"
   dependencies:
     archy "^1.0.0"
     arrify "^1.0.1"
@@ -1261,15 +1323,15 @@ nyc@^10.0.0:
     debug-log "^1.0.1"
     default-require-extensions "^1.0.0"
     find-cache-dir "^0.1.1"
-    find-up "^1.1.2"
+    find-up "^2.1.0"
     foreground-child "^1.5.3"
     glob "^7.0.6"
-    istanbul-lib-coverage "^1.0.0"
-    istanbul-lib-hook "^1.0.0-alpha.4"
-    istanbul-lib-instrument "^1.3.0"
-    istanbul-lib-report "^1.0.0-alpha.3"
-    istanbul-lib-source-maps "^1.1.0"
-    istanbul-reports "^1.0.0"
+    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-hook "^1.0.7"
+    istanbul-lib-instrument "^1.7.4"
+    istanbul-lib-report "^1.1.1"
+    istanbul-lib-source-maps "^1.2.1"
+    istanbul-reports "^1.1.1"
     md5-hex "^1.2.0"
     merge-source-map "^1.0.2"
     micromatch "^2.3.11"
@@ -1277,24 +1339,24 @@ nyc@^10.0.0:
     resolve-from "^2.0.0"
     rimraf "^2.5.4"
     signal-exit "^3.0.1"
-    spawn-wrap "^1.2.4"
-    test-exclude "^3.3.0"
-    yargs "^6.4.0"
-    yargs-parser "^4.0.2"
+    spawn-wrap "^1.3.8"
+    test-exclude "^4.1.1"
+    yargs "^8.0.1"
+    yargs-parser "^5.0.0"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-object-inspect@^1.1.0, object-inspect@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.2.1.tgz#3b62226eb8f6d441751c7d8f22a20ff80ac9dc3f"
+object-inspect@^1.1.0, object-inspect@~1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.2.2.tgz#c82115e4fcc888aea14d64c22e4f17f6a70d5e5a"
 
 object-keys@^1.0.8, object-keys@^1.0.9:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
-object.entries@^1.0.3:
+object.entries@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
   dependencies:
@@ -1316,9 +1378,11 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -1338,15 +1402,35 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-os-homedir@^1.0.0, os-homedir@^1.0.1:
+os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-locale@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+os-locale@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.0.0.tgz#15918ded510522b81ee7ae5a309d54f639fc39a4"
   dependencies:
+    execa "^0.5.0"
     lcid "^1.0.0"
+    mem "^1.1.0"
+
+os-tmpdir@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-limit@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -1373,17 +1457,31 @@ path-exists@^2.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -1392,6 +1490,12 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -1417,9 +1521,9 @@ plur@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/plur/-/plur-1.0.0.tgz#db85c6814f5e5e5a3b49efc28d604fec62975156"
 
-pluralize@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+pluralize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -1441,20 +1545,20 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-progress@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-pseudomap@^1.0.1:
+pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 randomatic@^1.1.3:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
   dependencies:
-    is-number "^2.0.2"
-    kind-of "^3.0.2"
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
 re-emitter@^1.0.0:
   version "1.1.3"
@@ -1467,6 +1571,13 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -1475,42 +1586,40 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.1.5, readable-stream@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
   dependencies:
-    buffer-shims "^1.0.0"
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
+
+readable-stream@^2.0.0, readable-stream@^2.1.5, readable-stream@^2.2.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  dependencies:
     core-util-is "~1.0.0"
-    inherits "~2.0.1"
+    inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
-
 regenerator-runtime@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz#257f41961ce44558b18f7814af48c17559f9faeb"
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regex-cache@^0.4.2:
   version "0.4.3"
-  resolved "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
   dependencies:
     is-equal-shallow "^0.1.3"
     is-primitive "^2.0.0"
+
+remove-trailing-separator@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
 
 repeat-element@^1.1.2:
   version "1.1.2"
@@ -1538,7 +1647,7 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
-require-uncached@^1.0.2:
+require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
@@ -1553,20 +1662,18 @@ resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
-resolve@^1.1.6, resolve@^1.1.7:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
-
-resolve@~1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+resolve@^1.1.7, resolve@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
+    path-parse "^1.0.5"
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
 
 resumer@~0.0.0:
   version "0.0.0"
@@ -1580,27 +1687,37 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
+rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.5.4, rimraf@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
-    once "^1.3.0"
+    is-promise "^2.1.0"
 
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
 
-samsam@1.1.2, samsam@~1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.2.0, semver@^5.3.0:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
+"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -1608,30 +1725,22 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
-shelljs@^0.7.5:
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.5.tgz#2eef7a50a21e1ccf37da00df767ec69e30ad0675"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-signal-exit@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-2.1.2.tgz#375879b1f92ebc3b334480d038dc546a6d558564"
-
-signal-exit@^3.0.0, signal-exit@^3.0.1:
+signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-sinon@^1.17.7:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+sinon@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.8.tgz#31de06fed8fba3a671e576dd96d0a5863796f25c"
   dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -1647,19 +1756,19 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-spawn-wrap@^1.2.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.3.4.tgz#5d133070fef81cd26d8259acaa07fc1a86fd45dc"
+spawn-wrap@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.3.8.tgz#fa2a79b990cbb0bb0018dca6748d88367b19ec31"
   dependencies:
     foreground-child "^1.5.6"
     mkdirp "^0.5.0"
     os-homedir "^1.0.1"
     rimraf "^2.3.3"
-    signal-exit "^2.0.0"
+    signal-exit "^3.0.2"
     which "^1.2.4"
 
 spdx-correct@~1.0.0:
@@ -1686,7 +1795,7 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-string-width@^1.0.1, string-width@^1.0.2:
+string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   dependencies:
@@ -1694,12 +1803,12 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+string-width@^2.0.0, string-width@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^3.0.0"
+    strip-ansi "^4.0.0"
 
 string.prototype.trim@~1.1.2:
   version "1.1.2"
@@ -1709,15 +1818,23 @@ string.prototype.trim@~1.1.2:
     es-abstract "^1.5.0"
     function-bind "^1.0.2"
 
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -1729,6 +1846,10 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -1738,14 +1859,20 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 supports-color@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
 
-table@^3.7.8:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+supports-color@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.0.tgz#ad986dc7eb2315d009b4d77c8169c2231a684037"
+  dependencies:
+    has-flag "^2.0.0"
+
+table@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.1.tgz#a8116c133fac2c61f4a420ab6cdf5c4d61f0e435"
   dependencies:
     ajv "^4.7.0"
     ajv-keywords "^1.0.0"
@@ -1776,33 +1903,37 @@ tap-spec@^4.1.1:
     tap-out "^1.4.1"
     through2 "^2.0.0"
 
-tape@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.6.3.tgz#637e77581e9ab2ce17577e9bd4ce4f575806d8b6"
+tape@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-4.7.0.tgz#f3ebb214fef3d6907e5a57dbaafe3bd8a7cbed88"
   dependencies:
     deep-equal "~1.0.1"
     defined "~1.0.0"
     for-each "~0.3.2"
     function-bind "~1.1.0"
-    glob "~7.1.1"
+    glob "~7.1.2"
     has "~1.0.1"
     inherits "~2.0.3"
     minimist "~1.2.0"
-    object-inspect "~1.2.1"
-    resolve "~1.1.7"
+    object-inspect "~1.2.2"
+    resolve "~1.3.3"
     resumer "~0.0.0"
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
 
-test-exclude@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-3.3.0.tgz#7a17ca1239988c98367b0621456dbb7d4bc38977"
+test-exclude@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
   dependencies:
     arrify "^1.0.1"
     micromatch "^2.3.11"
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -1823,9 +1954,19 @@ tmatch@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tmatch/-/tmatch-2.0.1.tgz#0c56246f33f30da1b8d3d72895abaf16660f38cf"
 
+tmp@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
 to-fast-properties@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 trim@0.0.1:
   version "0.0.1"
@@ -1841,38 +1982,30 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 uglify-js@^2.6:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
-    async "~0.2.6"
     source-map "~0.5.1"
-    uglify-to-browserify "~1.0.0"
     yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-user-home@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
-  dependencies:
-    os-homedir "^1.0.0"
-
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-"util@>=0.10.3 <1":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
-  dependencies:
-    inherits "2.0.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -1881,15 +2014,15 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-which-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
 which@^1.2.4, which@^1.2.9:
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
-    isexe "^1.1.1"
+    isexe "^2.0.0"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -1919,8 +2052,8 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
 write-file-atomic@^1.1.4:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.1.tgz#7d45ba32316328dd1ec7d90f60ebc0d845bb759a"
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
@@ -1932,7 +2065,7 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
@@ -1940,33 +2073,39 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-yallist@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.0.0.tgz#306c543835f09ee1a4cb23b7bce9ab341c91cdd4"
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs-parser@^4.0.2, yargs-parser@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
+yargs-parser@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
   dependencies:
     camelcase "^3.0.0"
 
-yargs@^6.4.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
-    camelcase "^3.0.0"
+    camelcase "^4.1.0"
+
+yargs@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  dependencies:
+    camelcase "^4.1.0"
     cliui "^3.2.0"
     decamelize "^1.1.1"
     get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^4.2.0"
+    yargs-parser "^7.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
### Changelog

- Revert the [revert](https://github.com/davidtheclark/cosmiconfig/commit/31467d4005fc9771a67af9614adc68ff76c7137b). Let me know if there's a better way.
- Fix issue with transform function resolution in `createExplorer.js`, details below
- Add test for transform option

### Details

The transform function was not being resolved correctly - [`lib/createExplorer.js#L16`](https://github.com/davidtheclark/cosmiconfig/blob/b57291583fcda08edad2aff43257de7fcb3c3938/lib/createExplorer.js#L16)
Here's a simple demo for what was going wrong:
```
λ node
> let sync = false

> 'someValidFunc' || (sync) ? 'identitySync' : 'identityPromise'
'identitySync'

> 'someValidFunc' || (sync ? 'identitySync' : 'identityPromise')
'someValidFunc'
```

And because the loaded config was not being transformed properly, stylelint was breaking(stylelint/stylelint#2768).

Closes #72