### PR TITLE
test: Add tests for 100% code coverage

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,11 @@ const oshomedir = require('os-homedir');
 const minimist = require('minimist');
 const createExplorer = require('./lib/createExplorer');
 
-const parsedCliArgs = minimist(process.argv);
-
 module.exports = function cosmiconfig(moduleName, options) {
+  // Keeping argv parsing here allows to mock `minimist` for different tests.
+  // This should not have too much of a negative impact.
+  const parsedCliArgs = minimist(process.argv);
+
   options = Object.assign(
     {
       packageProp: moduleName,

--- a/lib/createExplorer.js
+++ b/lib/createExplorer.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const path = require('path');
-const isDir = require('is-directory');
 const loadPackageProp = require('./loadPackageProp');
 const loadRc = require('./loadRc');
 const loadJs = require('./loadJs');
 const loadDefinedFile = require('./loadDefinedFile');
 const funcRunner = require('./funcRunner');
+const resolveDir = require('./resolveDir');
 
 module.exports = function createExplorer(options) {
   // When `options.sync` is `false` (default),
@@ -102,22 +102,6 @@ module.exports = function createExplorer(options) {
     clearCaches,
   };
 };
-
-function resolveDir(searchPath, sync) {
-  const dirForPath = pathIsDir =>
-    pathIsDir ? searchPath : path.dirname(searchPath);
-
-  if (sync === true) {
-    return dirForPath(isDir.sync(searchPath));
-  }
-
-  return new Promise((resolve, reject) => {
-    return isDir(searchPath, (err, pathIsDir) => {
-      if (err) return reject(err);
-      return resolve(dirForPath(pathIsDir));
-    });
-  });
-}
 
 function identity(x) {
   return x;

--- a/lib/resolveDir.js
+++ b/lib/resolveDir.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const path = require('path');
+const isDir = require('is-directory');
+
+/**
+ * Resolves difectory for given search path. Depending on the `sync` parameter,
+ * either a string or a `Promise` which resolves to a string is returned. If
+ * the given path is a directory, the same path is returned. If not, the parent
+ * directory is returned.
+ *
+ * @param {string} searchPath The path to detect and return the directory for.
+ * @param {boolean} sync If the value should be resolved synchronously or in a
+ * promise
+ * @returns {Promise<string> | string} The directory for the given path.
+ */
+module.exports = function resolveDir(searchPath, sync) {
+  const dirForPath = pathIsDir =>
+    pathIsDir ? searchPath : path.dirname(searchPath);
+
+  if (sync === true) {
+    return dirForPath(isDir.sync(searchPath));
+  }
+
+  return new Promise((resolve, reject) => {
+    return isDir(searchPath, (err, pathIsDir) => {
+      if (err) return reject(err);
+      return resolve(dirForPath(pathIsDir));
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -49,7 +49,11 @@
     "tabWidth": 2
   },
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "collectCoverageFrom": [
+      "lib/*.js",
+      "index.js"
+    ]
   },
   "dependencies": {
     "is-directory": "^0.3.1",

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -62,6 +62,18 @@ function makeEmptyFileTest(fileFormat, withFormat) {
 }
 
 describe('cosmiconfig', () => {
+  util.testSyncAndAsync(
+    'returns null if neither searchPath nor configPath are specified',
+    sync => () => {
+      expect.hasAssertions();
+      return util.testFuncsRunner(sync, cosmiconfig(null, { sync }).load(), [
+        result => {
+          expect(result).toBeNull();
+        },
+      ]);
+    }
+  );
+
   describe('load from file', () => {
     it('throws error if defined file does not exist', () => {
       expect.assertions(2);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// Mock `createExplorer` because we want to check what it is called with.
+jest.mock('../lib/createExplorer');
+// Mock `minimist` and also provide default implementation which returns an
+// empty object. The factory function returns a mock which we can tweak per
+// test basis.
+jest.mock('minimist', () => jest.fn(() => ({})));
+
+const path = require('path');
+const oshomedir = require('os-homedir');
+const cosmiconfig = require('../');
+
+const minimistMock = require('minimist');
+const createExplorerMock = require('../lib/createExplorer');
+
+describe('cosmiconfig', () => {
+  const moduleName = 'foo';
+  const stopDir = oshomedir();
+  const configPath = path.join(__dirname, 'fixtures/foo.json');
+
+  afterEach(() => {
+    // Clean up a mock's usage data between tests
+    jest.clearAllMocks();
+  });
+
+  it('creates explorer with default options if not specified', () => {
+    cosmiconfig(moduleName);
+
+    expect(createExplorerMock).toHaveBeenCalledTimes(1);
+    expect(createExplorerMock).toHaveBeenCalledWith({
+      packageProp: moduleName,
+      rc: `.${moduleName}rc`,
+      js: `${moduleName}.config.js`,
+      argv: 'config',
+      rcStrictJson: false,
+      stopDir,
+      cache: true,
+      sync: false,
+    });
+  });
+
+  it('creates explorer with preference for given options over defaults', () => {
+    cosmiconfig(moduleName, {
+      rc: `.${moduleName}barrc`,
+      js: `${moduleName}bar.config.js`,
+      argv: false,
+      rcStrictJson: true,
+      stopDir: __dirname,
+      cache: false,
+      sync: true,
+    });
+
+    expect(createExplorerMock).toHaveBeenCalledWith({
+      packageProp: moduleName,
+      rc: `.${moduleName}barrc`,
+      js: `${moduleName}bar.config.js`,
+      argv: false,
+      rcStrictJson: true,
+      stopDir: __dirname,
+      cache: false,
+      sync: true,
+    });
+  });
+
+  it('uses the --config flag by default', () => {
+    minimistMock.mockReturnValueOnce({ config: configPath });
+    cosmiconfig(moduleName);
+
+    expect(createExplorerMock).toHaveBeenCalledWith({
+      packageProp: moduleName,
+      rc: `.${moduleName}rc`,
+      js: `${moduleName}.config.js`,
+      argv: 'config',
+      rcStrictJson: false,
+      stopDir,
+      cache: true,
+      sync: false,
+      configPath,
+    });
+  });
+
+  it('does not use the --config flag if options.argv is false', () => {
+    minimistMock.mockReturnValueOnce({ config: configPath });
+    cosmiconfig(moduleName, { argv: false });
+
+    expect(createExplorerMock).toHaveBeenCalledWith({
+      packageProp: moduleName,
+      rc: `.${moduleName}rc`,
+      js: `${moduleName}.config.js`,
+      argv: false,
+      rcStrictJson: false,
+      stopDir,
+      cache: true,
+      sync: false,
+    });
+  });
+
+  it('uses the argv name specified by options for reading configPath', () => {
+    minimistMock.mockReturnValueOnce({ 'foo-config': configPath });
+    cosmiconfig(moduleName, { argv: 'foo-config' });
+
+    expect(createExplorerMock).toHaveBeenCalledWith({
+      packageProp: moduleName,
+      rc: `.${moduleName}rc`,
+      js: `${moduleName}.config.js`,
+      argv: 'foo-config',
+      rcStrictJson: false,
+      stopDir,
+      cache: true,
+      sync: false,
+      configPath,
+    });
+  });
+});

--- a/test/resolveDir.test.js
+++ b/test/resolveDir.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const util = require('./util');
+const resolveDir = require('../lib/resolveDir');
+
+const testFuncsRunner = util.testFuncsRunner;
+const testSyncAndAsync = util.testSyncAndAsync;
+
+describe('resolveDir', () => {
+  testSyncAndAsync(
+    'returns the searchPath if it is a directory',
+    sync => () => {
+      expect.hasAssertions();
+      return testFuncsRunner(sync, resolveDir(__dirname, sync), [
+        dir => {
+          expect(dir).toBe(__dirname);
+        },
+      ]);
+    }
+  );
+
+  testSyncAndAsync(
+    'returns the parent directory if it is a file',
+    sync => () => {
+      expect.hasAssertions();
+      return testFuncsRunner(sync, resolveDir(__filename, sync), [
+        dir => {
+          expect(dir).toBe(__dirname);
+        },
+      ]);
+    }
+  );
+
+  it('returns a promise if sync is not true', () => {
+    // Although we explicitly pass `false`, the result will be a promise even
+    // if a value was not passed, because it would be falsy and not exactly
+    // equal to `true`.
+    const res = resolveDir(__dirname, false);
+    expect(res).toBeInstanceOf(Promise);
+  });
+
+  it('propagates error thrown by is-directory in sync', () => {
+    expect(() => resolveDir(null, true)).toThrowError(
+      'expected filepath to be a string'
+    );
+  });
+
+  it('rejects with the error thrown by is-directory in async', () => {
+    expect.hasAssertions();
+    return resolveDir(null, false).catch(err => {
+      expect(err.message).toBe('expected filepath to be a string');
+    });
+  });
+});


### PR DESCRIPTION
Add tests:
- `caches`
  - `clearCaches` clears both file and directory cache.
  - Error not thrown when `clearFileCache`/`clearDirectoryCache`/`clearCaches`
    is called with cache disabled.
  - File results are not cached when it is disabled.
- `failed-files`
  - `null` is returned by `load` function when neither `searchPath` nor
    `configPath` are specified.
- `index`
  - Default options are passed to `createExplorer` if options are not passed.
  - Options passed in function paramter take precedence over defaults.
  - `--config` argument is used if available.
  - `--config` argument is not used if `options.argv` is `false`.
  - Custom argument flag can be specified and is used if available.
- `resolveDir`
  - `searchPath` is returned if it is a directory.
  - Parent directiry of `searchPath` is returned if it is a file.
  - A `Promise` is returned if `sync` is false.
  - Error thrown by `is-directory` is propagated in sync and the `Promise` is
    rejected in async.

Code changes for enabling unit tests:
- `index.js` - Parse arguments with `minimist` in each invocation of the
  function exported by `cosmiconfig`, not just on requiring the module.
- `createExplorer.js` - Move helper function `resolveDir` into separate file.