### PR TITLE
refactor: rm deprecated package os-homedir

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 'use strict';
 require('please-upgrade-node')(require('./package.json'));
 
+const os = require('os');
 const path = require('path');
-const oshomedir = require('os-homedir');
 const minimist = require('minimist');
 const createExplorer = require('./lib/createExplorer');
+
+const homedir = os.homedir();
 
 module.exports = function cosmiconfig(moduleName, options) {
   // Keeping argv parsing here allows to mock `minimist` for different tests.
@@ -18,7 +20,7 @@ module.exports = function cosmiconfig(moduleName, options) {
       js: `${moduleName}.config.js`,
       argv: 'config',
       rcStrictJson: false,
-      stopDir: oshomedir(),
+      stopDir: homedir,
       cache: true,
       sync: false,
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "is-promise": "^2.1.0",
     "js-yaml": "^3.9.0",
     "minimist": "^1.2.0",
-    "os-homedir": "^1.0.1",
     "parse-json": "^2.2.0",
     "please-upgrade-node": "^3.0.1",
     "require-from-string": "^1.1.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,8 +7,8 @@ jest.mock('../lib/createExplorer');
 // test basis.
 jest.mock('minimist', () => jest.fn(() => ({})));
 
+const os = require('os');
 const path = require('path');
-const oshomedir = require('os-homedir');
 const cosmiconfig = require('../');
 
 const minimistMock = require('minimist');
@@ -16,7 +16,7 @@ const createExplorerMock = require('../lib/createExplorer');
 
 describe('cosmiconfig', () => {
   const moduleName = 'foo';
-  const stopDir = oshomedir();
+  const stopDir = os.homedir();
   const configPath = path.join(__dirname, 'fixtures/foo.json');
 
   afterEach(() => {


### PR DESCRIPTION
The `os-homedir` package [is deprecated](https://github.com/sindresorhus/os-homedir) as the behavior is identical to `os.homedir()` on node 4 and above:
> This is not needed anymore. Use require('os').homedir() instead.

This PR removes the package and uses the `os` package instead.