### PR TITLE
Typecheck configPath cli argument. Defer path.resolve call to config lookup runtime.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 require('please-upgrade-node')(require('./package.json'));
 
 const os = require('os');
-const path = require('path');
 const minimist = require('minimist');
 const createExplorer = require('./lib/createExplorer');
 
@@ -27,8 +26,9 @@ module.exports = function cosmiconfig(moduleName, options) {
     options
   );
 
-  if (options.argv && parsedCliArgs[options.argv]) {
-    options.configPath = path.resolve(parsedCliArgs[options.argv]);
+  const configPath = parsedCliArgs[options.argv];
+  if (options.argv && configPath && typeof configPath === 'string') {
+    options.configPath = configPath;
   }
 
   return createExplorer(options);


### PR DESCRIPTION
See https://github.com/prettier/prettier/issues/2797 and https://github.com/prettier/prettier/pull/2798 for why this is needed.