### PR TITLE
ci: Whitelist build branches to avoid duplicate builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
   - "6"
   - "7"
   - "8"
+branches:
+  only:
+    - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ environment:
     - nodejs_version: 4
     - nodejs_version: 6
 
+branches:
+  only:
+    - master
+
 version: "{build}"
 build: off
 deploy: off


### PR DESCRIPTION
For pull requests which are made from a branch in this repo instead of a fork, travis and appveyor run duplicate builds once for the PR and once for the branch push. By whitelisting branches, we can limit builds to master and PR branches. To be clear, if a branch, with which a PR was made, is updated, that will still trigger a build.