### PR TITLE
Remove argv config option, don't parse process.argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Throw error on getting empty config file.
 - Removed: support for Node versions < 4.
 - Fixed: when a `options.configPath` is `package.json`, return the package prop, not the entire JSON file.
-- Removed: support for loading config path using the `--config` flag. cosmiconfig will not parse command line arguments.
+- Removed: support for loading config path using the `--config` flag. cosmiconfig will not parse command line arguments. Your application can parse command line arguments and pass them to cosmiconfig.
 - Removed: `argv` config option.
 ## 2.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - Added: `sync` option.
 - Throw error on getting empty config file.
 - Removed: support for Node versions < 4.
-- Fixed: when a `options.configPath` or `--config` is `package.json`, return the package prop, not the entire JSON file.
-
+- Fixed: when a `options.configPath` is `package.json`, return the package prop, not the entire JSON file.
+- Removed: support for loading config path using the `--config` flag. cosmiconfig will not parse command line arguments.
+- Removed: `argv` config option.
 ## 2.2.2
 
 - Fixed: `options.configPath` and `--config` flag are respected.

--- a/README.md
+++ b/README.md
@@ -120,17 +120,6 @@ Name of a JS file to look for, which must export the configuration object.
 
 If `false`, cosmiconfig will not look for a JS file.
 
-##### argv
-
-Type: `string` or `false`
-Default: `'config'`
-
-Name of a `process.argv` argument to look for, whose value should be the path to a configuration file.
-cosmiconfig will read the file and try to parse it as JSON, YAML, or JS.
-By default, cosmiconfig looks for `--config`.
-
-If `false`, cosmiconfig will not look for any `process.argv` arguments.
-
 ##### rcStrictJson
 
 Type: `boolean`

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
   "jest": {
     "testEnvironment": "node",
     "collectCoverageFrom": [
-      "src/*.js",
-      "index.js"
+      "src/*.js"
     ]
   },
   "babel": {
@@ -65,9 +64,7 @@
   "dependencies": {
     "is-directory": "^0.3.1",
     "js-yaml": "^3.9.0",
-    "minimist": "^1.2.0",
     "parse-json": "^2.2.0",
-    "please-upgrade-node": "^3.0.1",
     "require-from-string": "^1.1.0"
   },
   "devDependencies": {

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -13,7 +13,6 @@ module.exports = function createExplorer(options: {
   packageProp?: string | false,
   rc?: string | false,
   js?: string | false,
-  argv?: string | false,
   format?: 'json' | 'yaml' | 'js',
   rcStrictJson?: boolean,
   rcExtensions?: boolean,

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,7 @@
 // @flow
 'use strict';
 
-require('please-upgrade-node')(require('../package.json'));
-
 const os = require('os');
-const path = require('path');
-const minimist = require('minimist');
 const createExplorer = require('./createExplorer');
 
 const homedir = os.homedir();
@@ -16,7 +12,6 @@ module.exports = function cosmiconfig(
     packageProp?: string | false,
     rc?: string | false,
     js?: string | false,
-    argv?: string | false,
     format?: 'json' | 'yaml' | 'js',
     rcStrictJson?: boolean,
     rcExtensions?: boolean,
@@ -27,17 +22,12 @@ module.exports = function cosmiconfig(
     configPath?: string,
   }
 ) {
-  // Keeping argv parsing here allows to mock `minimist` for different tests.
-  // This should not have too much of a negative impact.
-  const parsedCliArgs = minimist(process.argv);
-
   options = Object.assign(
     {},
     {
       packageProp: moduleName,
       rc: `.${moduleName}rc`,
       js: `${moduleName}.config.js`,
-      argv: 'config',
       rcStrictJson: false,
       stopDir: homedir,
       cache: true,
@@ -45,10 +35,6 @@ module.exports = function cosmiconfig(
     },
     options
   );
-
-  if (options.argv && parsedCliArgs[options.argv]) {
-    options.configPath = path.resolve(parsedCliArgs[options.argv]);
-  }
 
   return createExplorer(options);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,22 +2,16 @@
 
 // Mock `createExplorer` because we want to check what it is called with.
 jest.mock('../src/createExplorer');
-// Mock `minimist` and also provide default implementation which returns an
-// empty object. The factory function returns a mock which we can tweak per
-// test basis.
-jest.mock('minimist', () => jest.fn(() => ({})));
 
 const os = require('os');
 const path = require('path');
 const cosmiconfig = require('../src');
 
-const minimistMock = require('minimist');
 const createExplorerMock = require('../src/createExplorer');
 
 describe('cosmiconfig', () => {
   const moduleName = 'foo';
   const stopDir = os.homedir();
-  const configPath = path.join(__dirname, 'fixtures/foo.json');
 
   afterEach(() => {
     // Clean up a mock's usage data between tests
@@ -32,7 +26,6 @@ describe('cosmiconfig', () => {
       packageProp: moduleName,
       rc: `.${moduleName}rc`,
       js: `${moduleName}.config.js`,
-      argv: 'config',
       rcStrictJson: false,
       stopDir,
       cache: true,
@@ -41,74 +34,25 @@ describe('cosmiconfig', () => {
   });
 
   it('creates explorer with preference for given options over defaults', () => {
+    const configPath = path.join(__dirname, 'fixtures/foo.json');
     cosmiconfig(moduleName, {
       rc: `.${moduleName}barrc`,
       js: `${moduleName}bar.config.js`,
-      argv: false,
       rcStrictJson: true,
       stopDir: __dirname,
       cache: false,
       sync: true,
+      configPath,
     });
 
     expect(createExplorerMock).toHaveBeenCalledWith({
       packageProp: moduleName,
       rc: `.${moduleName}barrc`,
       js: `${moduleName}bar.config.js`,
-      argv: false,
       rcStrictJson: true,
       stopDir: __dirname,
       cache: false,
       sync: true,
-    });
-  });
-
-  it('uses the --config flag by default', () => {
-    minimistMock.mockReturnValueOnce({ config: configPath });
-    cosmiconfig(moduleName);
-
-    expect(createExplorerMock).toHaveBeenCalledWith({
-      packageProp: moduleName,
-      rc: `.${moduleName}rc`,
-      js: `${moduleName}.config.js`,
-      argv: 'config',
-      rcStrictJson: false,
-      stopDir,
-      cache: true,
-      sync: false,
-      configPath,
-    });
-  });
-
-  it('does not use the --config flag if options.argv is false', () => {
-    minimistMock.mockReturnValueOnce({ config: configPath });
-    cosmiconfig(moduleName, { argv: false });
-
-    expect(createExplorerMock).toHaveBeenCalledWith({
-      packageProp: moduleName,
-      rc: `.${moduleName}rc`,
-      js: `${moduleName}.config.js`,
-      argv: false,
-      rcStrictJson: false,
-      stopDir,
-      cache: true,
-      sync: false,
-    });
-  });
-
-  it('uses the argv name specified by options for reading configPath', () => {
-    minimistMock.mockReturnValueOnce({ 'foo-config': configPath });
-    cosmiconfig(moduleName, { argv: 'foo-config' });
-
-    expect(createExplorerMock).toHaveBeenCalledWith({
-      packageProp: moduleName,
-      rc: `.${moduleName}rc`,
-      js: `${moduleName}.config.js`,
-      argv: 'foo-config',
-      rcStrictJson: false,
-      stopDir,
-      cache: true,
-      sync: false,
       configPath,
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,10 +2161,6 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-please-upgrade-node@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz#0a681f2c18915e5433a5ca2cd94e0b8206a782db"
-
 pluralize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"


### PR DESCRIPTION
### Motivation

See https://github.com/davidtheclark/cosmiconfig/pull/86#issuecomment-329036084

Related issue - prettier/prettier#2797

### Changelog

- Remove `argv` config option from flow type, default config values.
- Do not parse `process.argv` to extract `configPath`
- Remove/update tests for `argv`, `--config` flag.
- Remove unused dependencies `minimist` and `please-upgrade-node`.

Closes #86