### PR TITLE
Setup and do changes for 100% coverage thresholds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Find and load configuration from a package.json property, rc file, or CommonJS module",
   "main": "dist/index.js",
   "files": [
-    "index.js",
     "dist"
   ],
   "scripts": {
@@ -12,7 +11,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "pretest": "npm run lint && flow check",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:watch": "jest --watch",
     "coverage": "jest --coverage --coverageReporters=html --coverageReporters=text",
     "build": "flow-remove-types src --out-dir dist --quiet",
@@ -54,7 +53,15 @@
     "testEnvironment": "node",
     "collectCoverageFrom": [
       "src/*.js"
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
   },
   "babel": {
     "plugins": [

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -135,11 +135,10 @@ module.exports = function createExplorer(options: {
       result => {
         if (result) return result;
 
-        const splitPath = directory.split(path.sep);
-        const nextDirectory =
-          splitPath.length > 1 ? splitPath.slice(0, -1).join(path.sep) : null;
+        const nextDirectory = path.dirname(directory);
 
-        if (!nextDirectory || directory === options.stopDir) return null;
+        if (nextDirectory === directory || directory === options.stopDir)
+          return null;
 
         return searchDirectory(nextDirectory);
       },

--- a/src/loadRc.js
+++ b/src/loadRc.js
@@ -46,9 +46,9 @@ module.exports = function loadRc(
     let foundConfig = null;
     return funcRunner(readRcFile('json'), [
       (jsonContent: ?string) => {
-        if (foundConfig) {
-          return;
-        } else if (jsonContent) {
+        // Since this is the first try, config cannot have been found, so don't
+        // check `if (foundConfig)`.
+        if (jsonContent) {
           const successFilepath = `${filepath}.json`;
           foundConfig = {
             config: parseJson(jsonContent, successFilepath),
@@ -101,10 +101,8 @@ module.exports = function loadRc(
     ]);
   }
 
-  function readRcFile(extension: ?string): Promise<?string> | ?string {
-    const filepathWithExtension = extension
-      ? `${filepath}.${extension}`
-      : filepath;
+  function readRcFile(extension: string): Promise<?string> | ?string {
+    const filepathWithExtension = `${filepath}.${extension}`;
     return !options.sync
       ? readFile(filepathWithExtension)
       : readFile.sync(filepathWithExtension);

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -8,10 +8,10 @@ const configFileLoader = util.configFileLoader;
 const testFuncsRunner = util.testFuncsRunner;
 const testSyncAndAsync = util.testSyncAndAsync;
 
-function makeFileTest(file) {
+function makeFileTest(file, format) {
   return sync => () => {
     expect.hasAssertions();
-    return testFuncsRunner(sync, configFileLoader({ sync }, file), [
+    return testFuncsRunner(sync, configFileLoader({ sync, format }, file), [
       result => {
         expect(result.config).toEqual({
           foo: true,
@@ -24,25 +24,49 @@ function makeFileTest(file) {
 
 describe('cosmiconfig', () => {
   describe('load from file', () => {
-    testSyncAndAsync(
-      'loads defined JSON config path',
-      makeFileTest('fixtures/foo.json')
-    );
+    describe('format not specified', () => {
+      testSyncAndAsync(
+        'loads defined JSON config path',
+        makeFileTest('fixtures/foo.json')
+      );
 
-    testSyncAndAsync(
-      'loads defined YAML config path',
-      makeFileTest('fixtures/foo.yaml')
-    );
+      testSyncAndAsync(
+        'loads defined YAML config path',
+        makeFileTest('fixtures/foo.yaml')
+      );
 
-    testSyncAndAsync(
-      'loads defined JS config path',
-      makeFileTest('fixtures/foo.js')
-    );
+      testSyncAndAsync(
+        'loads defined JS config path',
+        makeFileTest('fixtures/foo.js')
+      );
 
-    testSyncAndAsync(
-      'loads modularized JS config path',
-      makeFileTest('fixtures/foo-module.js')
-    );
+      testSyncAndAsync(
+        'loads modularized JS config path',
+        makeFileTest('fixtures/foo-module.js')
+      );
+    });
+
+    describe('format specified', () => {
+      testSyncAndAsync(
+        'loads defined JSON config path',
+        makeFileTest('fixtures/foo.json', 'json')
+      );
+
+      testSyncAndAsync(
+        'loads defined YAML config path',
+        makeFileTest('fixtures/foo.yaml', 'yaml')
+      );
+
+      testSyncAndAsync(
+        'loads defined JS config path',
+        makeFileTest('fixtures/foo.js', 'js')
+      );
+
+      testSyncAndAsync(
+        'loads modularized JS config path',
+        makeFileTest('fixtures/foo-module.js', 'js')
+      );
+    });
 
     testSyncAndAsync('respects options.configPath', sync => () => {
       const configPath = absolutePath('fixtures/foo.json');
@@ -58,7 +82,7 @@ describe('cosmiconfig', () => {
     });
 
     testSyncAndAsync(
-      'loads package prop when --config is package.json',
+      'loads package prop when configPath is package.json',
       sync => () => {
         const configPath = absolutePath('fixtures/package.json');
         const explorer = cosmiconfig('foo', { configPath, sync });


### PR DESCRIPTION
Code coverage went down in #87 but we did not notice it:
```
λ yarn coverage
yarn coverage v1.0.2
$ jest --coverage --coverageReporters=html --coverageReporters=text
 PASS  test\caches.test.js
 PASS  test\failed-files.test.js
 PASS  test\failed-directories.test.js
 PASS  test\successful-directories.test.js
 PASS  test\successful-files.test.js
 PASS  test\resolveDir.test.js
 PASS  test\funcRunner.test.js
 PASS  test\index.test.js

Test Suites: 8 passed, 8 total
Tests:       104 passed, 104 total
Snapshots:   0 total
Time:        2.928s
Ran all test suites.
--------------------|----------|----------|----------|----------|----------------|
File                |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------------|----------|----------|----------|----------|----------------|
All files           |    98.13 |     98.6 |      100 |    97.95 |                |
 createExplorer.js  |      100 |      100 |      100 |      100 |                |
 funcRunner.js      |      100 |      100 |      100 |      100 |                |
 getDirectory.js    |      100 |      100 |      100 |      100 |                |
 index.js           |      100 |      100 |      100 |      100 |                |
 loadDefinedFile.js |    90.32 |      100 |      100 |    90.32 |       25,30,33 |
 loadJs.js          |      100 |      100 |      100 |      100 |                |
 loadPackageProp.js |      100 |      100 |      100 |      100 |                |
 loadRc.js          |    97.87 |    93.33 |      100 |    97.73 |             50 |
 parseJson.js       |      100 |      100 |      100 |      100 |                |
 readFile.js        |      100 |      100 |      100 |      100 |                |
--------------------|----------|----------|----------|----------|----------------|
Done in 6.45s.
```

This configures [coverage thresholds](https://facebook.github.io/jest/docs/en/configuration.html#coveragethreshold-object) for jest and does the necessary changes for 100% code coverage. Now, if any changes reduce the coverage, it will fail in CI. 