### PR TITLE
Fix UNC path issue reported in prettier/prettier-vscode#219

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "is-directory": "^0.3.1",
     "js-yaml": "^3.9.0",
     "parse-json": "^3.0.0",
-    "require-from-string": "^2.0.1"
+    "require-from-string": "^2.0.1",
+    "unc-path-regex": "^0.1.2"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.0",

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -141,7 +141,8 @@ module.exports = function createExplorer(options: {
         if (result) return result;
 
         // istanbul ignore if (test only runs on Windows)
-        if (isUncStopDir(directory)) return null;
+        if (process.platform === 'win32' && isUncStopDir(directory))
+          return null;
 
         const nextDirectory = path.dirname(directory);
 

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -10,6 +10,7 @@ const loadDefinedFile = require('./loadDefinedFile');
 const funcRunner = require('./funcRunner');
 const getDirectory = require('./getDirectory');
 
+// istanbul ignore next
 const isUncStopDir = (regExp => fsPath => regExp.test(fsPath))(
   new RegExp(`^${uncPathRegex().source}$`)
 );
@@ -140,7 +141,8 @@ module.exports = function createExplorer(options: {
       result => {
         if (result) return result;
 
-        // istanbul ignore if (test only runs on Windows)
+        // Test only runs on Windows
+        // istanbul ignore next
         if (process.platform === 'win32' && isUncStopDir(directory))
           return null;
 

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -2,12 +2,17 @@
 'use strict';
 
 const path = require('path');
+const uncPathRegex = require('unc-path-regex');
 const loadPackageProp = require('./loadPackageProp');
 const loadRc = require('./loadRc');
 const loadJs = require('./loadJs');
 const loadDefinedFile = require('./loadDefinedFile');
 const funcRunner = require('./funcRunner');
 const getDirectory = require('./getDirectory');
+
+const isUncStopDir = (regExp => fsPath => regExp.test(fsPath))(
+  new RegExp(`^${uncPathRegex().source}$`)
+);
 
 module.exports = function createExplorer(options: {
   packageProp?: string | false,
@@ -134,6 +139,9 @@ module.exports = function createExplorer(options: {
       },
       result => {
         if (result) return result;
+
+        // istanbul ignore if (test only runs on Windows)
+        if (isUncStopDir(directory)) return null;
 
         const nextDirectory = path.dirname(directory);
 

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -150,11 +150,16 @@ describe('cosmiconfig', () => {
           expect.hasAssertions();
           return testFuncsRunner(sync, loadConfig(startDir), [
             result => {
-              util.assertSearchSequence(readFileMock, [
-                '\\\\device\\c$\\a\\b\\package.json',
-                '\\\\device\\c$\\a\\package.json',
-                '\\\\device\\c$\\package.json',
-              ]);
+              util.assertSearchSequence(
+                readFileMock,
+                [
+                  '\\\\device\\c$\\a\\b\\package.json',
+                  '\\\\device\\c$\\a\\package.json',
+                  '\\\\device\\c$\\package.json',
+                ],
+                0,
+                true
+              );
               expect(result).toBe(null);
             },
           ]);

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -141,7 +141,11 @@ describe('cosmiconfig', () => {
           const readFileMock = mockReadFile(sync, readFile);
 
           const startDir = '\\\\device\\c$\\a\\b\\';
-          const loadConfig = cosmiconfig('foo', { sync }).load;
+          const loadConfig = cosmiconfig('foo', {
+            js: false,
+            rc: false,
+            sync,
+          }).load;
 
           expect.hasAssertions();
           return testFuncsRunner(sync, loadConfig(startDir), [

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -124,6 +124,40 @@ describe('cosmiconfig', () => {
       ]);
     });
 
+    if (process.platform === 'win32') {
+      testSyncAndAsync(
+        'stops at UNC path device name and gives up',
+        sync => () => {
+          function readFile(searchPath) {
+            switch (searchPath) {
+              case '\\\\device\\c$\\a\\b\\package.json':
+              case '\\\\device\\c$\\a\\package.json':
+              case '\\\\device\\c$\\package.json':
+                throw { code: 'ENOENT' };
+              default:
+                throw new Error(`irrelevant path ${searchPath}`);
+            }
+          }
+          const readFileMock = mockReadFile(sync, readFile);
+
+          const startDir = '\\\\device\\c$\\a\\b\\';
+          const loadConfig = cosmiconfig('foo', { sync }).load;
+
+          expect.hasAssertions();
+          return testFuncsRunner(sync, loadConfig(startDir), [
+            result => {
+              util.assertSearchSequence(readFileMock, [
+                '\\\\device\\c$\\a\\b\\package.json',
+                '\\\\device\\c$\\a\\package.json',
+                '\\\\device\\c$\\package.json',
+              ]);
+              expect(result).toBe(null);
+            },
+          ]);
+        }
+      );
+    }
+
     it('throws error for invalid YAML in rc file', () => {
       function readFile(searchPath) {
         switch (searchPath) {

--- a/test/util.js
+++ b/test/util.js
@@ -49,7 +49,8 @@ exports.mockStatIsDirectory = function mockStatIsDirectory(result) {
 exports.assertSearchSequence = function assertSearchSequence(
   readFileMock,
   searchPaths,
-  startCount
+  startCount,
+  isAbsolute
 ) {
   startCount = startCount || 0;
 
@@ -57,7 +58,7 @@ exports.assertSearchSequence = function assertSearchSequence(
 
   searchPaths.forEach((searchPath, idx) => {
     expect(readFileMock.mock.calls[idx + startCount][0]).toBe(
-      path.join(__dirname, searchPath)
+      path.join(isAbsolute ? '' : __dirname, searchPath)
     );
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,6 +3156,10 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
+unc-path-regex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
### DO NOT MERGE

I'm experimenting with a way to solve prettier/prettier-vscode#219, where cosmiconfig should stop moving up the directory tree in this case:

```
\\127.0.0.1\c$\a\b\c
\\127.0.0.1\c$\a\b
\\127.0.0.1\c$\a
\\127.0.0.1\c$
STOP - do not read \\127.0.0.1
```

Unfortunately, `path.dirname('\\x\y') === '\\x'`, which is not what we want.

Notes:
1. I wrote this on Mac and will need to run it through CI to see if it passes on Windows.
2. I should test this on an actual Windows machine.
3. Is it ok to have tests that only run on one platform?

