### PR TITLE
Bump parse-json from 3.0.0 to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## master
+
+- Licensing improvement: updated `parse-json` from `3.0.0` to `4.0.0`(see [sindresorhus/parse-json#12][parse-json-pr-12]).
+- Changed: error message format for `JSON` parse errors(see [#101][pr-101]). If you were relying on the format of JSON-parsing error messages, this will be a breaking change for you.
+
 ## 3.1.0
 
 - Added: infer format based on filePath
@@ -72,3 +77,6 @@
 ## 1.0.0
 
 - Initial release.
+
+[parse-json-pr-12]: https://github.com/sindresorhus/parse-json/pull/12
+[pr-101]: https://github.com/davidtheclark/cosmiconfig/pull/101

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "is-directory": "^0.3.1",
     "js-yaml": "^3.9.0",
-    "parse-json": "^3.0.0",
+    "parse-json": "^4.0.0",
     "require-from-string": "^2.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,6 +1975,10 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
+json-parse-better-errors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz#50183cd1b2d25275de069e9e71b467ac9eab973a"
+
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
@@ -2496,6 +2500,13 @@ parse-json@^3.0.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
   dependencies:
     error-ex "^1.3.1"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parse5@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
This bumps the version for package `parse-json` from `3.0.0` to `4.0.0`. Due to the difference in error messages generated by `parse-json`, it was a major version change(relevant PR - sindresorhus/parse-json#12). Here are some sample error messages before and after the version change:

***Before:***
``` 
JSON Error in E:\Projects\repos\cosmiconfig\test\fixtures\foo-invalid.json:
Unexpected token '\n' at 2:15
  "foo": true:
              ^
JSON Error in E:\Projects\repos\cosmiconfig\test\a\b\.foorc:
Trailing comma in object at 1:18
{ "found": true, }
                 ^
JSON Error in E:\Projects\repos\cosmiconfig\test\a\b\package.json:
Trailing comma in object at 1:17
{ "foo": "bar", }
                ^
JSON Error in E:\Projects\repos\cosmiconfig\test\a\b\c\d\e\f\.foorc.json:
Unexpected token ',' at 1:17
{ "found": true,, }
                ^
```

***After:***
```
JSON Error in E:\Projects\repos\cosmiconfig\test\fixtures\foo-invalid.json:
Unexpected token : in JSON at position 15 while parsing near '{  "foo": true:}'

JSON Error in E:\Projects\repos\cosmiconfig\test\a\b\.foorc:
Unexpected token } in JSON at position 17 while parsing near '{ "found": true, }'

JSON Error in E:\Projects\repos\cosmiconfig\test\a\b\package.json:
Unexpected token } in JSON at position 16 while parsing near '{ "foo": "bar", }'

JSON Error in E:\Projects\repos\cosmiconfig\test\a\b\c\d\e\f\.foorc.json:
Unexpected token , in JSON at position 16 while parsing near '{ "found": true,, }'
```

**NOTE:** It should be possible to derive the line and column position from the new format using something like [`string-pos`](https://www.npmjs.com/package/string-pos)

<details>
<summary>no longer relevant</summary>

I have a couple of questions:
- Is there any reason we should not update to this version of the package?
- Will this be a major version change for `cosmiconfig` as well?

</details>
<br>
cc @azz