### PR TITLE
Start search from process.cwd()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Licensing improvement: updated `parse-json` from `3.0.0` to `4.0.0`(see [sindresorhus/parse-json#12][parse-json-pr-12]).
 - Changed: error message format for `JSON` parse errors(see [#101][pr-101]). If you were relying on the format of JSON-parsing error messages, this will be a breaking change for you.
+- Changed: set default for `searchPath` as `process.cwd()` in `explorer.load`.
 
 ## 3.1.0
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var cosmiconfig = require('cosmiconfig');
 
 var explorer = cosmiconfig(yourModuleName[, options]);
 
-explorer.load(yourSearchPath)
+explorer.load()
   .then((result) => {
     // result.config is the parsed configuration object
     // result.filepath is the path to the config file that was found
@@ -198,9 +198,11 @@ Find and load a configuration file. Returns a Promise that resolves with `null`,
 - `config`: The loaded and parsed configuration.
 - `filepath`: The filepath where this configuration was found.
 
-You should provide *either* `searchPath` *or* `configPath`. Use `configPath` if you know the path of the configuration file you want to load. Otherwise, use `searchPath`.
+You should provide *either* `searchPath` *or* `configPath`. Use `configPath` if you know the path of the configuration file you want to load. Note that `configPath` takes priority over `searchPath` if both parameters are specified.
 
 ```js
+explorer.load()
+
 explorer.load('start/search/here');
 explorer.load('start/search/at/this/file.css');
 
@@ -208,6 +210,7 @@ explorer.load(null, 'load/this/file.json');
 ```
 
 If you provide `searchPath`, cosmiconfig will start its search at `searchPath` and continue to search up the directory tree, as documented above.
+By default, `searchPath` is set to `process.cwd()`.
 
 If you provide `configPath` (i.e. you already know where the configuration is that you want to load), cosmiconfig will try to read and parse that file. Note that the [`format` option](#format) is applicable for this as well.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "precommit": "lint-staged && jest && flow check",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"{src/*.js,test/*.js}\"",
     "pretest": "npm run lint && flow check",
     "test": "jest --coverage",
     "test:watch": "jest --watch",

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -54,9 +54,8 @@ module.exports = function createExplorer(options: {
     searchPath: string,
     configPath?: string
   ): Promise<?cosmiconfig$Result> | ?cosmiconfig$Result {
-    if (!configPath && options.configPath) {
-      configPath = options.configPath;
-    }
+    if (!searchPath) searchPath = process.cwd();
+    if (!configPath && options.configPath) configPath = options.configPath;
 
     if (configPath) {
       const absoluteConfigPath = path.resolve(process.cwd(), configPath);
@@ -94,8 +93,6 @@ module.exports = function createExplorer(options: {
       if (fileCache) fileCache.set(absoluteConfigPath, result);
       return result;
     }
-
-    if (!searchPath) return !options.sync ? Promise.resolve(null) : null;
 
     const absoluteSearchPath = path.resolve(process.cwd(), searchPath);
     const searchPathDir = getDirectory(absoluteSearchPath, options.sync);

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -79,18 +79,6 @@ function makeEmptyFileTest(fileFormat, withFormat) {
 }
 
 describe('cosmiconfig', () => {
-  util.testSyncAndAsync(
-    'returns null if neither searchPath nor configPath are specified',
-    sync => () => {
-      expect.hasAssertions();
-      return util.testFuncsRunner(sync, cosmiconfig(null, { sync }).load(), [
-        result => {
-          expect(result).toBeNull();
-        },
-      ]);
-    }
-  );
-
   describe('load from file', () => {
     it('throws error if defined file does not exist', () => {
       expect.assertions(2);


### PR DESCRIPTION
~~This adds an option `startDir`  with the defaults as `process.cwd()` and is used as the start directory for search if no parameters are passed to `explorer.load`.~~

This sets default value for `searchPath` as `process.cwd()` in `explorer.load`.

Closes #102. 