### PR TITLE
Treat empty files differently from non-existent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 5.0.0
 
 - Changed: `load([searchPath, configPath])` is now split into two functions `search([searchPath])` and `load([configPath])`.  The functionality of searching for a configuration and loading a configuration directly remains the same.
-
 - Changed: `clearFileCache()` and `clearDirectoryCache()` have been renamed to `clearLoadCache()` and `clearSearchPath()` respectively.
+- Changed: `load()` now returns an undefined config and an additional property `isEmpty: true` when loading an empty file.
+- Changed: `search()` now takes a second options argument which can be an object containing a single property `ignoreEmpty`.  This defaults to true and tells cosmiconfig whether to continue the search when an empty config file is found.
 
 ## 4.0.0
 

--- a/README.md
+++ b/README.md
@@ -192,26 +192,38 @@ In the event that the file does not have an extension or the extension is unreco
 
 ### Instance methods (on `explorer`)
 
-#### `search([searchPath])`
+#### `search([searchPath][, searchOptions])`
 
 Searches for a configuration file. Returns a Promise that resolves with `null`, if nothing is found, or an object with two properties:
 - `config`: The loaded and parsed configuration.
 - `filepath`: The filepath where this configuration was found.
 
+When the [search option](#searchoptions) `ignoreEmpty` is set to false and an empty configuration file is found, the result will have `config` set to `undefined` and an additional property `isEmpty` set to true.
+
 ```js
 explorer.search() // searches from process.cwd()
 explorer.search('start/search/here');
 explorer.search('start/search/at/this/file.css');
+
+// will stop on an empty configuration file
+explorer.search('start/search/here', { ignoreEmpty: false })
 ```
 
 If you provide `searchPath`, cosmiconfig will start its search at `searchPath` and continue to search up the directory tree, as documented above.
 By default, `searchPath` is set to `process.cwd()`.
+
+##### searchOptions
+
+Can be an object containing a single property `ignoreEmpty`.  This defaults to true and tells cosmiconfig whether to continue searching
+for files when an empty one is found.
 
 #### `load([configPath])`
 
 Loads a configuration file directly.  Rejects with an error if the file does not exist, if the file contents are empty, or if the file cannot be parsed.  Upon success it returns a Promise that resolves with an object with two properties:
 - `config`: The loaded and parsed configuration.
 - `filepath`: The filepath where this configuration was found.
+
+If the file is empty then `config` will be set to `undefined` and an additional property `isEmpty` will be set to true
 
 ```js
 explorer.load() // loads options.configPath

--- a/flow-typed/defs.js
+++ b/flow-typed/defs.js
@@ -1,4 +1,5 @@
 type cosmiconfig$Result = {
   config: any,
   filepath: string,
+  isEmpty?: boolean,
 };

--- a/src/createParseFile.js
+++ b/src/createParseFile.js
@@ -1,7 +1,11 @@
 'use strict';
 
-module.exports = function createParseFile(filepath, parse, ignoreEmpty) {
-  return function parseFile(content) {
+module.exports = function createParseFile(
+  filepath: string,
+  parse: (string, string) => Object,
+  ignoreEmpty: boolean
+): string => cosmiconfig$Result {
+  return function parseFile(content: string): cosmiconfig$Result {
     const isEmpty = content === '';
     if (content == null || (isEmpty && ignoreEmpty)) return null;
 

--- a/src/createParseFile.js
+++ b/src/createParseFile.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function createParseFile(filepath, parse, ignoreEmpty) {
+  return function parseFile(content) {
+    const isEmpty = content === '';
+    if (content == null || (isEmpty && ignoreEmpty)) return null;
+
+    return isEmpty
+      ? { config: undefined, filepath, isEmpty }
+      : { config: parse(content, filepath), filepath };
+  };
+};

--- a/src/loadDefinedFile.js
+++ b/src/loadDefinedFile.js
@@ -16,7 +16,7 @@ module.exports = function loadDefinedFile(
 ): Promise<?cosmiconfig$Result> | ?cosmiconfig$Result {
   function parseContent(content: ?string): ?cosmiconfig$Result {
     if (!content) {
-      throw new Error(`Config file is empty! Filepath - "${filepath}".`);
+      return { config: undefined, filepath, isEmpty: true };
     }
 
     let parsedConfig;

--- a/src/loadJs.js
+++ b/src/loadJs.js
@@ -3,19 +3,17 @@
 
 const requireFromString = require('require-from-string');
 const readFile = require('./readFile');
+const createParseFile = require('./createParseFile');
 
 module.exports = function loadJs(
   filepath: string,
-  options: { sync?: boolean }
+  options: { ignoreEmpty: boolean, sync?: boolean }
 ): Promise<?cosmiconfig$Result> | ?cosmiconfig$Result {
-  function parseJsFile(content: ?string): ?cosmiconfig$Result {
-    if (!content) return null;
-
-    return {
-      config: requireFromString(content, filepath),
-      filepath,
-    };
-  }
+  const parseJsFile = createParseFile(
+    filepath,
+    requireFromString,
+    options.ignoreEmpty
+  );
 
   return !options.sync
     ? readFile(filepath).then(parseJsFile)

--- a/src/loadRc.js
+++ b/src/loadRc.js
@@ -6,15 +6,25 @@ const requireFromString = require('require-from-string');
 const readFile = require('./readFile');
 const parseJson = require('./parseJson');
 const funcRunner = require('./funcRunner');
+const createParseFile = require('./createParseFile');
 
 module.exports = function loadRc(
   filepath: string,
   options: {
+    ignoreEmpty: boolean,
     sync?: boolean,
     rcStrictJson?: boolean,
     rcExtensions?: boolean,
   }
 ): Promise<?cosmiconfig$Result> | ?cosmiconfig$Result {
+  const parseYaml = (content, filename) => yaml.safeLoad(content, { filename });
+  const parse = options.rcStrictJson ? parseJson : parseYaml;
+  const parseExtensionlessRcFile = createParseFile(
+    filepath,
+    parse,
+    options.ignoreEmpty
+  );
+
   if (!options.sync) {
     return readFile(filepath)
       .then(parseExtensionlessRcFile)
@@ -31,73 +41,32 @@ module.exports = function loadRc(
     return null;
   }
 
-  function parseExtensionlessRcFile(content: ?string): ?cosmiconfig$Result {
-    if (!content) return null;
-    const pasedConfig = options.rcStrictJson
-      ? parseJson(content, filepath)
-      : yaml.safeLoad(content, { filename: filepath });
-    return {
-      config: pasedConfig,
-      filepath,
-    };
-  }
-
   function loadRcWithExtensions() {
-    let foundConfig = null;
-    return funcRunner(readRcFile('json'), [
-      (jsonContent: ?string) => {
-        // Since this is the first try, config cannot have been found, so don't
-        // check `if (foundConfig)`.
-        if (jsonContent) {
-          const successFilepath = `${filepath}.json`;
-          foundConfig = {
-            config: parseJson(jsonContent, successFilepath),
-            filepath: successFilepath,
-          };
-        } else {
-          return readRcFile('yaml');
-        }
-      },
-      (yamlContent: ?string) => {
-        if (foundConfig) {
-          return;
-        } else if (yamlContent) {
-          const successFilepath = `${filepath}.yaml`;
-          foundConfig = {
-            config: yaml.safeLoad(yamlContent, { filename: successFilepath }),
-            filepath: successFilepath,
-          };
-        } else {
-          return readRcFile('yml');
-        }
-      },
-      (ymlContent: ?string) => {
-        if (foundConfig) {
-          return;
-        } else if (ymlContent) {
-          const successFilepath = `${filepath}.yml`;
-          foundConfig = {
-            config: yaml.safeLoad(ymlContent, { filename: successFilepath }),
-            filepath: successFilepath,
-          };
-        } else {
-          return readRcFile('js');
-        }
-      },
-      (jsContent: ?string) => {
-        if (foundConfig) {
-          return;
-        } else if (jsContent) {
-          const successFilepath = `${filepath}.js`;
-          foundConfig = {
-            config: requireFromString(jsContent, successFilepath),
-            filepath: successFilepath,
-          };
-        } else {
-          return;
-        }
-      },
-      () => foundConfig,
+    function loadExtension(
+      extension: string,
+      parse: (content: string, filename: string) => Object
+    ) {
+      const fpath = `${filepath}.${extension}`;
+      const parseRcFile = createParseFile(fpath, parse, options.ignoreEmpty);
+
+      // Check the result from the previous `loadExtension` invocation. If result
+      // isn't null, just return that.
+      return result => {
+        if (result != null) return result;
+
+        // Try to load the rc file for the given extension.
+        return funcRunner(readRcFile(extension), [parseRcFile]);
+      };
+    }
+
+    const parseYml = (content: string, filename: string) =>
+      yaml.safeLoad(content, { filename });
+
+    return funcRunner(!options.sync ? Promise.resolve() : undefined, [
+      loadExtension('json', parseJson),
+      loadExtension('yaml', parseYml),
+      loadExtension('yml', parseYml),
+      loadExtension('js', requireFromString),
     ]);
   }
 

--- a/src/loadRc.js
+++ b/src/loadRc.js
@@ -55,7 +55,7 @@ module.exports = function loadRc(
         if (result != null) return result;
 
         // Try to load the rc file for the given extension.
-        return funcRunner(readRcFile(extension), [parseRcFile]);
+        return funcRunner(readRcFile(fpath), [parseRcFile]);
       };
     }
 
@@ -70,10 +70,7 @@ module.exports = function loadRc(
     ]);
   }
 
-  function readRcFile(extension: string): Promise<?string> | ?string {
-    const filepathWithExtension = `${filepath}.${extension}`;
-    return !options.sync
-      ? readFile(filepathWithExtension)
-      : readFile.sync(filepathWithExtension);
+  function readRcFile(filepath: string): Promise<?string> | ?string {
+    return !options.sync ? readFile(filepath) : readFile.sync(filepath);
   }
 };

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -347,6 +347,7 @@ describe('cosmiconfig', () => {
               throw { code: 'ENOENT' };
             case absolutePath('a/b/c/d/e/f/.foorc.json'):
             case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+              // This proves the default 'ignoreEmpty' skips over these files as expected
               return '';
             case absolutePath('a/b/c/d/e/f/.foorc.yml'):
               return 'found: thing: true';
@@ -374,10 +375,9 @@ describe('cosmiconfig', () => {
             case absolutePath('a/b/c/d/e/f/package.json'):
             case absolutePath('a/b/c/d/e/f/.foorc'):
             case absolutePath('a/b/c/d/e/f/.foorc.json'):
-              throw { code: 'ENOENT' };
             case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
             case absolutePath('a/b/c/d/e/f/.foorc.yml'):
-              return '';
+              throw { code: 'ENOENT' };
             case absolutePath('a/b/c/d/e/f/.foorc.js'):
               return 'module.exports = found: true };';
             default:

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -68,13 +68,19 @@ function makeEmptyFileTest(fileFormat, withFormat) {
   const file = `fixtures/foo-empty.${fileFormat}`;
   return () => {
     expect.assertions(2);
-    expect(() => configFileLoader({ sync: true, format }, file)).toThrow(
-      /^Config file is empty/
+    const expectedResult = {
+      config: undefined,
+      filepath: path.join(__dirname, file),
+      isEmpty: true,
+    };
+
+    expect(configFileLoader({ sync: true, format }, file)).toEqual(
+      expectedResult
     );
 
-    return configFileLoader({ format }, file).catch(err => {
-      expect(err.message).toMatch(/^Config file is empty/);
-    });
+    return expect(configFileLoader({ format }, file)).resolves.toEqual(
+      expectedResult
+    );
   };
 }
 
@@ -109,11 +115,20 @@ describe('cosmiconfig', () => {
         makeSyntaxErrTest('js')
       );
 
-      it('throws error for empty file, format JS', makeEmptyFileTest('js'));
+      it(
+        'returns an empty config result for an empty file, format JS',
+        makeEmptyFileTest('js')
+      );
 
-      it('throws error for empty file, format JSON', makeEmptyFileTest('json'));
+      it(
+        'returns an empty config result for an empty file, format JSON',
+        makeEmptyFileTest('json')
+      );
 
-      it('throws error for empty file, format YAML', makeEmptyFileTest('yaml'));
+      it(
+        'returns an empty config result for an empty file, format YAML',
+        makeEmptyFileTest('yaml')
+      );
     });
 
     describe('with expected format', () => {
@@ -133,17 +148,17 @@ describe('cosmiconfig', () => {
       );
 
       it(
-        'throws error for empty file, format JS',
+        'returns an empty config result for an empty file, format JS',
         makeEmptyFileTest('js', true)
       );
 
       it(
-        'throws error for empty file, format JSON',
+        'returns an empty config result for an empty file, format JSON',
         makeEmptyFileTest('json', true)
       );
 
       it(
-        'throws error for empty file, format YAML',
+        'returns an empty config result for an empty file, format YAML',
         makeEmptyFileTest('yaml', true)
       );
     });


### PR DESCRIPTION
- Return an 'undefined' config along with the file path for empty
  configuration files when both traversing directories and loading
  defined files.  Previously empty configuration files would prompt
  an error upon loading defined files and be silently passed over
  during directory traversal.

BREAKING CHANGE: treats empty files differently