### PR TITLE
add support for precompiled modules

### DIFF
--- a/src/loadDefinedFile.js
+++ b/src/loadDefinedFile.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const yaml = require('js-yaml');
-const requireFromString = require('require-from-string');
+const requireJs = require('./requireJs');
 const readFile = require('./readFile');
 const parseJson = require('./parseJson');
 const path = require('path');
@@ -31,7 +31,7 @@ module.exports = function loadDefinedFile(
         });
         break;
       case 'js':
-        parsedConfig = requireFromString(content, filepath);
+        parsedConfig = requireJs(content, filepath);
         break;
       default:
         parsedConfig = tryAllParsing(content, filepath);
@@ -91,8 +91,12 @@ function tryYaml(content: string, filepath: string, cb: () => ?Object) {
 
 function tryRequire(content: string, filepath: string, cb: () => ?Object) {
   try {
-    return requireFromString(content, filepath);
+    return requireJs(content, filepath);
   } catch (e) {
+    if (e.code === 'ES_MODULES_DEFAULT_REQUIRED') {
+      throw e;
+    }
+
     return cb();
   }
 }

--- a/src/loadJs.js
+++ b/src/loadJs.js
@@ -1,7 +1,7 @@
 // @flow
 'use strict';
 
-const requireFromString = require('require-from-string');
+const requireJs = require('./requireJs');
 const readFile = require('./readFile');
 const createParseFile = require('./createParseFile');
 
@@ -9,11 +9,7 @@ module.exports = function loadJs(
   filepath: string,
   options: { ignoreEmpty: boolean, sync?: boolean }
 ): Promise<?cosmiconfig$Result> | ?cosmiconfig$Result {
-  const parseJsFile = createParseFile(
-    filepath,
-    requireFromString,
-    options.ignoreEmpty
-  );
+  const parseJsFile = createParseFile(filepath, requireJs, options.ignoreEmpty);
 
   return !options.sync
     ? readFile(filepath).then(parseJsFile)

--- a/src/loadRc.js
+++ b/src/loadRc.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const yaml = require('js-yaml');
-const requireFromString = require('require-from-string');
+const requireJs = require('./requireJs');
 const readFile = require('./readFile');
 const parseJson = require('./parseJson');
 const funcRunner = require('./funcRunner');
@@ -66,7 +66,7 @@ module.exports = function loadRc(
       loadExtension('json', parseJson),
       loadExtension('yaml', parseYml),
       loadExtension('yml', parseYml),
-      loadExtension('js', requireFromString),
+      loadExtension('js', requireJs),
     ]);
   }
 

--- a/src/requireJs.js
+++ b/src/requireJs.js
@@ -1,0 +1,30 @@
+// @flow
+'use strict';
+
+const requireFromString = require('require-from-string');
+
+function requireJs(content: string, filepath: string) {
+  let result = requireFromString(content, filepath);
+
+  /**
+   * Handle ES Modules
+   */
+  if (typeof result === 'object' && result.__esModule) {
+    if (result.default) {
+      result = result.default;
+    } else {
+      const error = new Error(
+        `${filepath} must use default export with ES Modules`
+      );
+
+      // $FlowFixMe
+      error.code = 'ES_MODULES_DEFAULT_REQUIRED';
+
+      throw error;
+    }
+  }
+
+  return result;
+}
+
+module.exports = requireJs;

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -120,6 +120,8 @@ describe('cosmiconfig', () => {
         makeEmptyFileTest('js')
       );
 
+      it('throws error for empty file, format JS', makeEmptyFileTest('js'));
+
       it(
         'returns an empty config result for an empty file, format JSON',
         makeEmptyFileTest('json')
@@ -178,6 +180,11 @@ describe('cosmiconfig', () => {
         'throws error if defined JS file has syntax error',
         makeSyntaxErrWithoutKnownExtnameTest('js')
       );
+
+      it(
+        'throws error if defined JS ES Modules file has syntax error',
+        makeSyntaxErrWithoutKnownExtnameTest('cjs-es-module-js')
+      );
     });
 
     it('returns null if configuration file does not exist', () => {
@@ -211,6 +218,34 @@ describe('cosmiconfig', () => {
     it('throws an error if no configPath was specified', () => {
       const load = sync => cosmiconfig('not_exist_rc_name', { sync }).load();
       const errorRegex = /^configPath must be a nonempty string/;
+
+      expect.assertions(2);
+      expect(() => load(true)).toThrow(errorRegex);
+
+      return load(false).catch(error => {
+        expect(error.message).toMatch(errorRegex);
+      });
+    });
+
+    it('throws an error if non-default es module', () => {
+      const load = sync =>
+        cosmiconfig('foo', { sync }).load(
+          path.join(__dirname, 'fixtures/cjs-es-module-missing-default.js')
+        );
+      const errorRegex = /must use default export with ES Modules/;
+
+      expect.assertions(2);
+      expect(() => load(true)).toThrow(errorRegex);
+
+      return load(false).catch(error => {
+        expect(error.message).toMatch(errorRegex);
+      });
+    });
+
+    it('throws an error if non-default es module with missing extension', () => {
+      const load = sync =>
+        configFileLoader({ sync }, 'fixtures/cjs-es-module-missing-default');
+      const errorRegex = /must use default export with ES Modules/;
 
       expect.assertions(2);
       expect(() => load(true)).toThrow(errorRegex);

--- a/test/fixtures/cjs-es-module-invalid-syntax.js
+++ b/test/fixtures/cjs-es-module-invalid-syntax.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+const config = {
+  foo,
+};
+
+exports.default = config;

--- a/test/fixtures/cjs-es-module-missing-default
+++ b/test/fixtures/cjs-es-module-missing-default
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+const config = {
+  foo: true
+};
+
+exports.config = config;

--- a/test/fixtures/cjs-es-module-missing-default.js
+++ b/test/fixtures/cjs-es-module-missing-default.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+const config = {
+  foo: true,
+};
+
+exports.config = config;

--- a/test/fixtures/cjs-es-module.js
+++ b/test/fixtures/cjs-es-module.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+const config = {
+  foo: true,
+};
+
+exports.default = config;

--- a/test/fixtures/foo-invalid-cjs-es-module-js
+++ b/test/fixtures/foo-invalid-cjs-es-module-js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+const config = {
+  foo,
+};
+
+exports.default = config;

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -46,6 +46,11 @@ describe('cosmiconfig', () => {
       );
 
       testSyncAndAsync(
+        'loads defined JS ES Modules config path',
+        makeFileTest('fixtures/cjs-es-module.js')
+      );
+
+      testSyncAndAsync(
         'loads yaml-like JS config path',
         makeFileTest('fixtures/foo-yaml-like.js')
       );
@@ -70,6 +75,11 @@ describe('cosmiconfig', () => {
       testSyncAndAsync(
         'loads modularized JS config path',
         makeFileTest('fixtures/foo-module.js', 'js')
+      );
+
+      testSyncAndAsync(
+        'loads defined JS ES Modules config path',
+        makeFileTest('fixtures/cjs-es-module.js', 'js')
       );
 
       testSyncAndAsync(


### PR DESCRIPTION
PR for https://github.com/davidtheclark/cosmiconfig/issues/109.

I think this is missing some tests for files ``test/successful-directories.test.js`` ``test/failed-directories.test.js``. I am not sure how those tests work.

If there is anything else missing, or you'd like something changed just let me know! It currently throws when es modules are detected without a default export.

If you'd rather this be PR to master, I have that ready as well.