### PR TITLE
add IDE files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 coverage
 *.DS_Store
 dist
+.idea
+.vscode


### PR DESCRIPTION
Add Webstorm's ``.idea`` and VS Code's ``.vscode`` folders to ``.gitignore``.