### PR TITLE
Test refactor (without source code change) in preparation for async-sync source code refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 coverage
 *.DS_Store
 dist
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Find and load a configuration object from
 - a JSON or YAML "rc file" (anywhere up the directory tree)
 - a `.config.js` CommonJS module (anywhere up the directory tree)
 
-For example, if your module's name is "soursocks," cosmiconfig will search out configuration in the following places:
+For example, if your module's name is "soursocks", cosmiconfig will search out configuration in the following places:
 
 - a `soursocks` property in `package.json` (anywhere up the directory tree)
 - a `.soursocksrc` file in JSON or YAML format (anywhere up the directory tree)

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -9,8 +9,6 @@ const cosmiconfig = require('../src');
 
 const absolutePath = util.absolutePath;
 const mockStatIsDirectory = util.mockStatIsDirectory;
-const testFuncsRunner = util.testFuncsRunner;
-const testSyncAndAsync = util.testSyncAndAsync;
 
 beforeAll(() => {
   function readFile(searchPath) {
@@ -44,7 +42,7 @@ beforeAll(() => {
   jest.spyOn(fsMock, 'readFileSync').mockImplementation(readFile);
 });
 
-afterEach(() => {
+function resetFsMocks() {
   // Resets all information stored in the mock,
   // including any inital implementation given.
   fsMock.stat.mockReset();
@@ -53,377 +51,395 @@ afterEach(() => {
   // Clean up a mock's usage data between tests
   fsMock.readFile.mockClear();
   fsMock.readFileSync.mockClear();
+}
+
+afterEach(() => {
+  resetFsMocks();
 });
 
 afterAll(() => {
-  jest.resetAllMockss();
+  jest.resetAllMocks();
 });
 
-const cachedSearch = cosmiconfig('foo').search;
-const cachedSearchSync = cosmiconfig('foo', { sync: true }).search;
-const cachedLoad = cosmiconfig('foo').load;
-const cachedLoadSync = cosmiconfig('foo', { sync: true }).load;
-const cachedSearchFor = sync =>
-  sync === true ? cachedSearchSync : cachedSearch;
-const cachedLoadFor = sync => (sync === true ? cachedLoadSync : cachedLoad);
-const readFileMockFor = sync =>
-  sync === true ? fsMock.readFileSync : fsMock.readFile;
+// const cachedLoaderFor = sync =>
+//   sync === true ? cachedLoadConfigSync : cachedLoadConfig;
+// const readFileMockFor = sync =>
+//   sync === true ? fsMock.readFileSync : fsMock.readFile;
 
-describe('cosmiconfig', () => {
-  describe('cache', () => {
-    testSyncAndAsync('is not used initially', sync => () => {
-      const search = cachedSearchFor(sync);
-      const searchPath = absolutePath('a/b/c/d/e');
-      mockStatIsDirectory(true);
-
-      expect.hasAssertions();
-      return testFuncsRunner(sync, search(searchPath), [
-        result => {
-          util.assertSearchSequence(readFileMockFor(sync), [
-            'a/b/c/d/e/package.json',
-            'a/b/c/d/e/.foorc',
-            'a/b/c/d/e/foo.config.js',
-            'a/b/c/d/package.json',
-            'a/b/c/d/.foorc',
-          ]);
-          expect(result).toEqual({
-            filepath: absolutePath('a/b/c/d/.foorc'),
-            config: { foundInD: true },
-          });
-        },
-      ]);
+describe('is not used initially', () => {
+  const searchPath = absolutePath('a/b/c/d/e');
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/package.json',
+      'a/b/c/d/e/.foorc',
+      'a/b/c/d/e/foo.config.js',
+      'a/b/c/d/package.json',
+      'a/b/c/d/.foorc',
+    ]);
+    expect(result).toEqual({
+      filepath: absolutePath('a/b/c/d/.foorc'),
+      config: { foundInD: true },
     });
+  };
 
-    testSyncAndAsync('is used for already visited directories', sync => () => {
-      const search = cachedSearchFor(sync);
-      // E and D visited above
-      const searchPath = absolutePath('a/b/c/d/e');
-      mockStatIsDirectory(true);
-
-      expect.hasAssertions();
-      return testFuncsRunner(sync, search(searchPath), [
-        result => {
-          expect(readFileMockFor(sync)).toHaveBeenCalledTimes(0);
-          expect(result).toEqual({
-            filepath: absolutePath('a/b/c/d/.foorc'),
-            config: { foundInD: true },
-          });
-        },
-      ]);
+  test('async', () => {
+    mockStatIsDirectory(true);
+    const cachedLoadConfig = cosmiconfig('foo').load;
+    return cachedLoadConfig(searchPath).then(result => {
+      checkResult(fsMock.readFile, result);
     });
-
-    testSyncAndAsync(
-      'is used when some directories in search are already visted',
-      sync => () => {
-        const search = cachedSearchFor(sync);
-        // E and D visited above, not F
-        const searchPath = absolutePath('a/b/c/d/e/f');
-        mockStatIsDirectory(true);
-
-        expect.hasAssertions();
-        return testFuncsRunner(sync, search(searchPath), [
-          result => {
-            util.assertSearchSequence(readFileMockFor(sync), [
-              'a/b/c/d/e/f/package.json',
-              'a/b/c/d/e/f/.foorc',
-              'a/b/c/d/e/f/foo.config.js',
-            ]);
-            expect(result).toEqual({
-              filepath: absolutePath('a/b/c/d/.foorc'),
-              config: { foundInD: true },
-            });
-          },
-        ]);
-      }
-    );
-
-    testSyncAndAsync('is not used for unvisited config file', sync => () => {
-      const load = cachedLoadFor(sync);
-      // B not yet visited
-      const configFile = absolutePath('a/b/package.json');
-      mockStatIsDirectory(false);
-
-      expect.hasAssertions();
-      return testFuncsRunner(sync, load(configFile), [
-        result => {
-          expect(readFileMockFor(sync)).toHaveBeenCalledTimes(1);
-          expect(result).toEqual({
-            filepath: absolutePath('a/b/package.json'),
-            config: { foundInB: true },
-          });
-        },
-      ]);
-    });
-
-    testSyncAndAsync(
-      'is not used in a new cosmiconfig instance',
-      sync => () => {
-        const search = cosmiconfig('foo', { sync }).search;
-        const searchPath = absolutePath('a/b/c/d/e');
-        mockStatIsDirectory(true);
-
-        expect.hasAssertions();
-        return testFuncsRunner(sync, search(searchPath), [
-          result => {
-            util.assertSearchSequence(readFileMockFor(sync), [
-              'a/b/c/d/e/package.json',
-              'a/b/c/d/e/.foorc',
-              'a/b/c/d/e/foo.config.js',
-              'a/b/c/d/package.json',
-              'a/b/c/d/.foorc',
-            ]);
-            expect(result).toEqual({
-              filepath: absolutePath('a/b/c/d/.foorc'),
-              config: { foundInD: true },
-            });
-          },
-        ]);
-      }
-    );
-
-    testSyncAndAsync('still works on old instance', sync => () => {
-      const search = cachedSearchFor(sync);
-      const searchPath = absolutePath('a/b/c/d/e');
-      mockStatIsDirectory(true);
-
-      expect.hasAssertions();
-      return testFuncsRunner(sync, search(searchPath), [
-        result => {
-          expect(readFileMockFor(sync)).toHaveBeenCalledTimes(0);
-          expect(result).toEqual({
-            filepath: absolutePath('a/b/c/d/.foorc'),
-            config: { foundInD: true },
-          });
-        },
-      ]);
-    });
-
-    testSyncAndAsync(
-      'clears load cache on calling clearLoadCache',
-      sync => () => {
-        const explorer = cosmiconfig('foo', { sync });
-        const searchPath = absolutePath('a/b/c/d/.foorc');
-        mockStatIsDirectory(false);
-
-        const expectedResult = {
-          filepath: absolutePath('a/b/c/d/.foorc'),
-          config: { foundInD: true },
-        };
-        const readFileMock = readFileMockFor(sync);
-
-        function expectation(result) {
-          util.assertSearchSequence(readFileMock, ['a/b/c/d/.foorc']);
-          expect(result).toEqual(expectedResult);
-        }
-
-        expect.hasAssertions();
-        return testFuncsRunner(sync, explorer.load(searchPath), [
-          expectation,
-          () => explorer.load(searchPath),
-          expectation,
-          () => {
-            explorer.clearLoadCache();
-          },
-          () => explorer.load(searchPath),
-          result => {
-            util.assertSearchSequence(readFileMock, [
-              'a/b/c/d/.foorc',
-              'a/b/c/d/.foorc',
-            ]);
-            expect(result).toEqual(expectedResult);
-          },
-        ]);
-      }
-    );
-
-    testSyncAndAsync(
-      'clears search cache on calling clearSearchCache',
-      sync => () => {
-        const explorer = cosmiconfig('foo', { sync });
-        const searchPath = absolutePath('a/b/c/d/e');
-        mockStatIsDirectory(true);
-
-        const expectedResult = {
-          filepath: absolutePath('a/b/c/d/.foorc'),
-          config: { foundInD: true },
-        };
-        const readFileMock = readFileMockFor(sync);
-
-        function expectation(result) {
-          util.assertSearchSequence(readFileMock, [
-            'a/b/c/d/e/package.json',
-            'a/b/c/d/e/.foorc',
-            'a/b/c/d/e/foo.config.js',
-            'a/b/c/d/package.json',
-            'a/b/c/d/.foorc',
-          ]);
-          expect(result).toEqual(expectedResult);
-        }
-
-        expect.hasAssertions();
-        return testFuncsRunner(sync, explorer.search(searchPath), [
-          expectation,
-          () => explorer.search(searchPath),
-          expectation,
-          () => {
-            explorer.clearSearchCache();
-          },
-          () => explorer.search(searchPath),
-          result => {
-            util.assertSearchSequence(readFileMock, [
-              'a/b/c/d/e/package.json',
-              'a/b/c/d/e/.foorc',
-              'a/b/c/d/e/foo.config.js',
-              'a/b/c/d/package.json',
-              'a/b/c/d/.foorc',
-              'a/b/c/d/e/package.json',
-              'a/b/c/d/e/.foorc',
-              'a/b/c/d/e/foo.config.js',
-              'a/b/c/d/package.json',
-              'a/b/c/d/.foorc',
-            ]);
-            expect(result).toEqual(expectedResult);
-          },
-        ]);
-      }
-    );
-
-    testSyncAndAsync(
-      'clears both load and search cache on calling clearCaches',
-      sync => () => {
-        const explorer = cosmiconfig('foo', { sync });
-        const searchPathFile = absolutePath('a/b/c/d/.foorc');
-        const searchPathDir = absolutePath('a/b/c/d/e');
-        mockStatIsDirectory(true);
-
-        const expectedResult = {
-          filepath: absolutePath('a/b/c/d/.foorc'),
-          config: { foundInD: true },
-        };
-        const readFileMock = readFileMockFor(sync);
-
-        function freshLoadFileExpect(result) {
-          util.assertSearchSequence(readFileMock, ['a/b/c/d/.foorc']);
-          expect(result).toEqual(expectedResult);
-          readFileMock.mockClear();
-        }
-
-        function freshLoadDirExpect(result) {
-          util.assertSearchSequence(readFileMock, [
-            'a/b/c/d/e/package.json',
-            'a/b/c/d/e/.foorc',
-            'a/b/c/d/e/foo.config.js',
-            'a/b/c/d/package.json',
-            'a/b/c/d/.foorc',
-          ]);
-          expect(result).toEqual(expectedResult);
-          readFileMock.mockClear();
-        }
-
-        function loadFromFile() {
-          mockStatIsDirectory(false);
-          return explorer.load(searchPathFile);
-        }
-
-        function loadFromDir() {
-          mockStatIsDirectory(true);
-          return explorer.search(searchPathDir);
-        }
-
-        expect.hasAssertions();
-        return testFuncsRunner(sync, loadFromFile(), [
-          freshLoadFileExpect,
-          loadFromFile,
-          result => {
-            // cachedSearchFileExpect
-            expect(readFileMock).not.toHaveBeenCalled();
-            expect(result).toEqual(expectedResult);
-          },
-          loadFromDir,
-          freshLoadDirExpect,
-          loadFromDir,
-          result => {
-            // cachedSearchDirExpect
-            expect(readFileMock).not.toHaveBeenCalled(); // so no need to clear
-            expect(result).toEqual(expectedResult);
-          },
-          () => {
-            explorer.clearCaches();
-          },
-          loadFromDir,
-          freshLoadDirExpect,
-          loadFromFile,
-          freshLoadFileExpect,
-        ]);
-      }
-    );
   });
 
-  describe('cache disabled', () => {
-    const explorer = cosmiconfig('foo', { cache: false });
-
-    it('does not throw an error when clearLoadCache is called', () => {
-      expect(() => explorer.clearLoadCache()).not.toThrow();
-    });
-
-    it('does not throw an error when clearSearchCache is called', () => {
-      expect(() => explorer.clearSearchCache()).not.toThrow();
-    });
-    it('does not throw an error when clearCaches is called', () => {
-      expect(() => explorer.clearCaches()).not.toThrow();
-    });
-
-    testSyncAndAsync('does not cache search results', sync => () => {
-      const search = cosmiconfig('foo', { sync, cache: false }).search;
-      const searchPath = absolutePath('a/b/c/d');
-      mockStatIsDirectory(true);
-
-      const expectedResult = {
-        filepath: absolutePath('a/b/c/d/.foorc'),
-        config: { foundInD: true },
-      };
-      const readFileMock = readFileMockFor(sync);
-
-      function expectation(result) {
-        util.assertSearchSequence(readFileMock, [
-          'a/b/c/d/package.json',
-          'a/b/c/d/.foorc',
-        ]);
-        expect(result).toEqual(expectedResult);
-        readFileMock.mockClear();
-      }
-
-      expect.hasAssertions();
-      return testFuncsRunner(sync, search(searchPath), [
-        expectation,
-        () => search(searchPath),
-        expectation,
-      ]);
-    });
-
-    testSyncAndAsync('does not cache load results', sync => () => {
-      const explorer = cosmiconfig('foo', { sync, cache: false });
-      const searchPath = absolutePath('a/b/c/d/.foorc');
-      mockStatIsDirectory(false);
-
-      const expectedResult = {
-        filepath: absolutePath('a/b/c/d/.foorc'),
-        config: { foundInD: true },
-      };
-      const readFileMock = readFileMockFor(sync);
-
-      function expectation(result) {
-        util.assertSearchSequence(readFileMock, ['a/b/c/d/.foorc']);
-        expect(result).toEqual(expectedResult);
-        readFileMock.mockClear();
-      }
-
-      expect.hasAssertions();
-      return testFuncsRunner(sync, explorer.load(searchPath), [
-        expectation,
-        () => explorer.load(searchPath),
-        expectation,
-      ]);
-    });
+  test('sync', () => {
+    mockStatIsDirectory(true);
+    const cachedLoadConfigSync = cosmiconfig('foo', { sync: true }).load;
+    const result = cachedLoadConfigSync(searchPath);
+    checkResult(fsMock.readFileSync, result);
   });
 });
+
+describe('cache is used for already visited directories', () => {
+  const searchPath = absolutePath('a/b/c/d/e');
+  const checkResult = (readFileMock, result) => {
+    expect(readFileMock).toHaveBeenCalledTimes(0);
+    expect(result).toEqual({
+      filepath: absolutePath('a/b/c/d/.foorc'),
+      config: { foundInD: true },
+    });
+  };
+
+  test('async', () => {
+    mockStatIsDirectory(true);
+    const cachedLoadConfig = cosmiconfig('foo').load;
+    mockStatIsDirectory(true);
+    // First pass (tested above) ...
+    return cachedLoadConfig(searchPath)
+      .then(() => {
+        // Reset mocks and search again.
+        resetFsMocks();
+        mockStatIsDirectory(true);
+        return cachedLoadConfig(searchPath);
+      })
+      .then(result => {
+        checkResult(fsMock.readFile, result);
+      });
+  });
+
+  test('sync', () => {
+    mockStatIsDirectory(true);
+    const cachedLoadConfigSync = cosmiconfig('foo', { sync: true }).load;
+    // First pass (tested above) ...
+    cachedLoadConfigSync(searchPath);
+    // Reset mocks and search again.
+    resetFsMocks();
+    mockStatIsDirectory(true);
+    const result = cachedLoadConfigSync(searchPath);
+    checkResult(fsMock.readFileSync, result);
+  });
+});
+
+// describe(
+//   'is used when some directories in search are already visted',
+//   sync => () => {
+//     const loadConfig = cachedLoaderFor(sync);
+//     // E and D visited above, not F
+//     const searchPath = absolutePath('a/b/c/d/e/f');
+//     mockStatIsDirectory(true);
+
+//     expect.hasAssertions();
+//     return testFuncsRunner(sync, loadConfig(searchPath), [
+//       result => {
+//         util.assertSearchSequence(readFileMockFor(sync), [
+//           'a/b/c/d/e/f/package.json',
+//           'a/b/c/d/e/f/.foorc',
+//           'a/b/c/d/e/f/foo.config.js',
+//         ]);
+//         expect(result).toEqual({
+//           filepath: absolutePath('a/b/c/d/.foorc'),
+//           config: { foundInD: true },
+//         });
+//       },
+//     ]);
+//   }
+// );
+
+// describe('is not used for unvisited config file', () => {
+//   const loadConfig = cachedLoaderFor(sync);
+//   // B not yet visited
+//   const configFile = absolutePath('a/b/package.json');
+//   mockStatIsDirectory(false);
+
+//   expect.hasAssertions();
+//   return testFuncsRunner(sync, loadConfig(null, configFile), [
+//     result => {
+//       expect(readFileMockFor(sync)).toHaveBeenCalledTimes(1);
+//       expect(result).toEqual({
+//         filepath: absolutePath('a/b/package.json'),
+//         config: { foundInB: true },
+//       });
+//     },
+
+// describe(
+//   'is not used in a new cosmiconfig instance',
+//   sync => () => {
+//     const loadConfig = cosmiconfig('foo', { sync }).load;
+//     const searchPath = absolutePath('a/b/c/d/e');
+//     mockStatIsDirectory(true);
+
+//     expect.hasAssertions();
+//     return testFuncsRunner(sync, loadConfig(searchPath), [
+//       result => {
+//         util.assertSearchSequence(readFileMockFor(sync), [
+//           'a/b/c/d/e/package.json',
+//           'a/b/c/d/e/.foorc',
+//           'a/b/c/d/e/foo.config.js',
+//           'a/b/c/d/package.json',
+//           'a/b/c/d/.foorc',
+//         ]);
+//         expect(result).toEqual({
+//           filepath: absolutePath('a/b/c/d/.foorc'),
+//           config: { foundInD: true },
+//         });
+//       },
+//     ]);
+//   }
+// );
+
+// describe('still works on old instance', () => {
+//   const loadConfig = cachedLoaderFor(sync);
+//   const searchPath = absolutePath('a/b/c/d/e');
+//   mockStatIsDirectory(true);
+
+//   expect.hasAssertions();
+//   return testFuncsRunner(sync, loadConfig(searchPath), [
+//     result => {
+//       expect(readFileMockFor(sync)).toHaveBeenCalledTimes(0);
+//       expect(result).toEqual({
+//         filepath: absolutePath('a/b/c/d/.foorc'),
+//         config: { foundInD: true },
+//       });
+//     },
+
+// describe(
+//   'clears file cache on calling clearFileCache',
+//   sync => () => {
+//     const explorer = cosmiconfig('foo', { sync });
+//     const searchPath = absolutePath('a/b/c/d/.foorc');
+//     mockStatIsDirectory(false);
+
+//     const expectedResult = {
+//       filepath: absolutePath('a/b/c/d/.foorc'),
+//       config: { foundInD: true },
+//     };
+//     const readFileMock = readFileMockFor(sync);
+
+//     function expectation(result) {
+//       util.assertSearchSequence(readFileMock, ['a/b/c/d/.foorc']);
+//       expect(result).toEqual(expectedResult);
+//     }
+
+//     expect.hasAssertions();
+//     return testFuncsRunner(sync, explorer.load(null, searchPath), [
+//       expectation,
+//       () => explorer.load(null, searchPath),
+//       expectation,
+//       () => {
+//         explorer.clearFileCache();
+//       },
+//       () => explorer.load(null, searchPath),
+//       result => {
+//         util.assertSearchSequence(readFileMock, [
+//           'a/b/c/d/.foorc',
+//           'a/b/c/d/.foorc',
+//         ]);
+//         expect(result).toEqual(expectedResult);
+//       },
+//     ]);
+
+// describe(
+//   'clears directory cache on calling clearDirectoryCache',
+//   sync => () => {
+//     const explorer = cosmiconfig('foo', { sync });
+//     const searchPath = absolutePath('a/b/c/d/e');
+//     mockStatIsDirectory(true);
+
+//     const expectedResult = {
+//       filepath: absolutePath('a/b/c/d/.foorc'),
+//       config: { foundInD: true },
+//     };
+//     const readFileMock = readFileMockFor(sync);
+
+//     function expectation(result) {
+//       util.assertSearchSequence(readFileMock, [
+//         'a/b/c/d/e/package.json',
+//         'a/b/c/d/e/.foorc',
+//         'a/b/c/d/e/foo.config.js',
+//         'a/b/c/d/package.json',
+//         'a/b/c/d/.foorc',
+//       ]);
+//       expect(result).toEqual(expectedResult);
+//     }
+
+//     expect.hasAssertions();
+//     return testFuncsRunner(sync, explorer.load(searchPath), [
+//       expectation,
+//       () => explorer.load(searchPath),
+//       expectation,
+//       () => {
+//         explorer.clearDirectoryCache();
+//       },
+//       () => explorer.load(searchPath),
+//       result => {
+//         util.assertSearchSequence(readFileMock, [
+//           'a/b/c/d/e/package.json',
+//           'a/b/c/d/e/.foorc',
+//           'a/b/c/d/e/foo.config.js',
+//           'a/b/c/d/package.json',
+//           'a/b/c/d/.foorc',
+//           'a/b/c/d/e/package.json',
+//           'a/b/c/d/e/.foorc',
+//           'a/b/c/d/e/foo.config.js',
+//           'a/b/c/d/package.json',
+//           'a/b/c/d/.foorc',
+//         ]);
+//         expect(result).toEqual(expectedResult);
+//       },
+//     ]);
+
+// describe(
+//   'clears both file and directory cache on calling clearCaches',
+//   sync => () => {
+//     const explorer = cosmiconfig('foo', { sync });
+//     const searchPathFile = absolutePath('a/b/c/d/.foorc');
+//     const searchPathDir = absolutePath('a/b/c/d/e');
+//     mockStatIsDirectory(true);
+
+//     const expectedResult = {
+//       filepath: absolutePath('a/b/c/d/.foorc'),
+//       config: { foundInD: true },
+//     };
+//     const readFileMock = readFileMockFor(sync);
+
+//     function freshLoadFileExpect(result) {
+//       util.assertSearchSequence(readFileMock, ['a/b/c/d/.foorc']);
+//       expect(result).toEqual(expectedResult);
+//       readFileMock.mockClear();
+//     }
+
+//     function freshLoadDirExpect(result) {
+//       util.assertSearchSequence(readFileMock, [
+//         'a/b/c/d/e/package.json',
+//         'a/b/c/d/e/.foorc',
+//         'a/b/c/d/e/foo.config.js',
+//         'a/b/c/d/package.json',
+//         'a/b/c/d/.foorc',
+//       ]);
+//       expect(result).toEqual(expectedResult);
+//       readFileMock.mockClear();
+//     }
+
+//     function loadFromFile() {
+//       mockStatIsDirectory(false);
+//       return explorer.load(null, searchPathFile);
+//     }
+
+//     function loadFromDir() {
+//       mockStatIsDirectory(true);
+//       return explorer.load(searchPathDir);
+//     }
+
+//     expect.hasAssertions();
+//     return testFuncsRunner(sync, loadFromFile(), [
+//       freshLoadFileExpect,
+//       loadFromFile,
+//       result => {
+//         // cachedLoadFileExpect
+//         expect(readFileMock).not.toHaveBeenCalled();
+//         expect(result).toEqual(expectedResult);
+//       },
+//       loadFromDir,
+//       freshLoadDirExpect,
+//       loadFromDir,
+//       result => {
+//         // cachedLoadDirExpect
+//         expect(readFileMock).not.toHaveBeenCalled(); // so no need to clear
+//         expect(result).toEqual(expectedResult);
+//       },
+//       () => {
+//         explorer.clearCaches();
+//       },
+//       loadFromDir,
+//       freshLoadDirExpect,
+//       loadFromFile,
+//       freshLoadFileExpect,
+//     ]);
+//   }
+// );
+// });
+
+// describe('cache disabled', () => {
+// const explorer = cosmiconfig('foo', { cache: false });
+
+// it('does not throw an error when clearFileCache is called', () => {
+//   expect(() => explorer.clearFileCache()).not.toThrow();
+// });
+
+// it('does not throw an error when clearDirectoryCache is called', () => {
+//   expect(() => explorer.clearDirectoryCache()).not.toThrow();
+// });
+// it('does not throw an error when clearCaches is called', () => {
+//   expect(() => explorer.clearCaches()).not.toThrow();
+// });
+
+// describe('does not cache directory results', () => {
+//   const loadConfig = cosmiconfig('foo', { sync, cache: false }).load;
+//   const searchPath = absolutePath('a/b/c/d');
+//   mockStatIsDirectory(true);
+
+//   const expectedResult = {
+//     filepath: absolutePath('a/b/c/d/.foorc'),
+//     config: { foundInD: true },
+//   };
+//   const readFileMock = readFileMockFor(sync);
+
+//   function expectation(result) {
+//     util.assertSearchSequence(readFileMock, [
+//       'a/b/c/d/package.json',
+//       'a/b/c/d/.foorc',
+//     ]);
+//     expect(result).toEqual(expectedResult);
+//     readFileMock.mockClear();
+//   }
+
+//   expect.hasAssertions();
+//   return testFuncsRunner(sync, loadConfig(searchPath), [
+//     expectation,
+//     () => loadConfig(searchPath),
+//     expectation,
+//   ]);
+// });
+
+// describe('does not cache file results', () => {
+//   const explorer = cosmiconfig('foo', { sync, cache: false });
+//   const searchPath = absolutePath('a/b/c/d/.foorc');
+//   mockStatIsDirectory(false);
+
+//   const expectedResult = {
+//     filepath: absolutePath('a/b/c/d/.foorc'),
+//     config: { foundInD: true },
+//   };
+//   const readFileMock = readFileMockFor(sync);
+
+//   function expectation(result) {
+//     util.assertSearchSequence(readFileMock, ['a/b/c/d/.foorc']);
+//     expect(result).toEqual(expectedResult);
+//     readFileMock.mockClear();
+//   }
+
+//   expect.hasAssertions();
+//   return testFuncsRunner(sync, explorer.load(null, searchPath), [
+//     expectation,
+//     () => explorer.load(null, searchPath),
+//     expectation,
+//   ]);
+// });

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -9,8 +9,6 @@ const cosmiconfig = require('../src');
 
 const absolutePath = util.absolutePath;
 const mockReadFile = util.mockReadFile;
-const testFuncsRunner = util.testFuncsRunner;
-const testSyncAndAsync = util.testSyncAndAsync;
 
 beforeAll(() => {
   util.mockStatIsDirectory(true);
@@ -31,471 +29,404 @@ afterAll(() => {
   jest.resetAllMocks();
 });
 
-const statMockFor = sync => (sync === true ? fsMock.statSync : fsMock.stat);
+describe('gives up if it cannot find the file', () => {
+  const startDir = absolutePath('a/b');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/package.json'):
+      case absolutePath('a/b/.foorc'):
+      case absolutePath('a/b/foo.config.js'):
+      case absolutePath('a/package.json'):
+      case absolutePath('a/.foorc'):
+      case absolutePath('a/foo.config.js'):
+      case absolutePath('package.json'):
+      case absolutePath('.foorc'):
+      case absolutePath('foo.config.js'):
+        throw { code: 'ENOENT' };
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
 
-describe('cosmiconfig', () => {
-  describe('search from directory', () => {
-    testSyncAndAsync('gives up if it cannot find the file', sync => () => {
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/package.json'):
-          case absolutePath('a/b/.foorc'):
-          case absolutePath('a/b/foo.config.js'):
-          case absolutePath('a/package.json'):
-          case absolutePath('a/.foorc'):
-          case absolutePath('a/foo.config.js'):
-          case absolutePath('package.json'):
-          case absolutePath('.foorc'):
-          case absolutePath('foo.config.js'):
-            throw { code: 'ENOENT' };
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-      const readFileMock = mockReadFile(sync, readFile);
-      const statMock = statMockFor(sync);
+  const checkResult = (statMock, readFileMock, result) => {
+    expect(statMock).toHaveBeenCalledTimes(1);
+    expect(statMock.mock.calls[0][0]).toBe(startDir);
 
-      const startDir = absolutePath('a/b');
-      const search = cosmiconfig('foo', {
-        stopDir: absolutePath('.'),
-        sync,
-      }).search;
+    util.assertSearchSequence(readFileMock, [
+      'a/b/package.json',
+      'a/b/.foorc',
+      'a/b/foo.config.js',
+      'a/package.json',
+      'a/.foorc',
+      'a/foo.config.js',
+      './package.json',
+      './.foorc',
+      './foo.config.js',
+    ]);
+    expect(result).toBe(null);
+  };
 
-      expect.hasAssertions();
-      return testFuncsRunner(sync, search(startDir), [
-        result => {
-          expect(statMock).toHaveBeenCalledTimes(1);
-          expect(statMock.mock.calls[0][0]).toBe(startDir);
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .then(result => {
+        checkResult(fsMock.stat, readFileMock, result);
+      });
+  });
 
-          util.assertSearchSequence(readFileMock, [
-            'a/b/package.json',
-            'a/b/.foorc',
-            'a/b/foo.config.js',
-            'a/package.json',
-            'a/.foorc',
-            'a/foo.config.js',
-            './package.json',
-            './.foorc',
-            './foo.config.js',
-          ]);
-          expect(result).toBe(null);
-        },
-      ]);
-    });
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(fsMock.statSync, readFileMock, result);
+  });
+});
 
-    testSyncAndAsync('stops at stopDir and gives up', sync => () => {
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/package.json'):
-          case absolutePath('a/b/.foorc'):
-          case absolutePath('a/b/foo.config.js'):
-          case absolutePath('a/package.json'):
-          case absolutePath('a/.foorc'):
-          case absolutePath('a/foo.config.js'):
-          case absolutePath('/package.json'):
-          case absolutePath('/.foorc'):
-          case absolutePath('/foo.config.js'):
-            throw { code: 'ENOENT' };
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-      const readFileMock = mockReadFile(sync, readFile);
+describe('stops at stopDir and gives up', () => {
+  const startDir = absolutePath('a/b');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/package.json'):
+      case absolutePath('a/b/.foorc'):
+      case absolutePath('a/b/foo.config.js'):
+      case absolutePath('a/package.json'):
+      case absolutePath('a/.foorc'):
+      case absolutePath('a/foo.config.js'):
+      case absolutePath('/package.json'):
+      case absolutePath('/.foorc'):
+      case absolutePath('/foo.config.js'):
+        throw { code: 'ENOENT' };
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
 
-      const startDir = absolutePath('a/b');
-      const search = cosmiconfig('foo', {
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/package.json',
+      'a/b/.foorc',
+      'a/b/foo.config.js',
+      'a/package.json',
+      'a/.foorc',
+      'a/foo.config.js',
+    ]);
+    expect(result).toBe(null);
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      stopDir: absolutePath('a'),
+    })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      stopDir: absolutePath('a'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('throws error for invalid YAML in rc file', () => {
+  const startDir = absolutePath('a/b');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/package.json'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/.foorc'):
+        return 'found: true: broken';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkError = error => {
+    expect(error.name).toBe('YAMLException');
+  };
+
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', { stopDir: absolutePath('a') })
+      .search(startDir)
+      .catch(checkError);
+  });
+
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    expect.hasAssertions();
+    try {
+      cosmiconfig('foo', { stopDir: absolutePath('a'), sync: true }).search(
+        startDir
+      );
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
+
+describe('throws error for invalid JSON in rc file with rcStrictJson', () => {
+  const startDir = absolutePath('a/b');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/package.json'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/.foorc'):
+        return 'found: true: broken';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkError = error => {
+    expect(error.name).toMatch(/JSONError/);
+  };
+
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcStrictJson: true,
+      stopDir: absolutePath('a'),
+    })
+      .search(startDir)
+      .catch(checkError);
+  });
+
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    expect.hasAssertions();
+    try {
+      cosmiconfig('foo', {
+        rcStrictJson: true,
         stopDir: absolutePath('a'),
-        sync,
-      }).search;
+        sync: true,
+      }).search(startDir);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
 
-      expect.hasAssertions();
-      return testFuncsRunner(sync, search(startDir), [
-        result => {
-          util.assertSearchSequence(readFileMock, [
-            'a/b/package.json',
-            'a/b/.foorc',
-            'a/b/foo.config.js',
-            'a/package.json',
-            'a/.foorc',
-            'a/foo.config.js',
-          ]);
-          expect(result).toBe(null);
-        },
-      ]);
-    });
+describe('throws error for invalid package.json', () => {
+  const startDir = absolutePath('a/b');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/package.json'):
+        return '{ "foo": "bar", }';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
 
-    it('returns an empty config result for empty rc file', () => {
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/package.json'):
-          case absolutePath('a/b/.foorc'):
-            return '';
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-      mockReadFile(true, readFile);
-      mockReadFile(false, readFile);
+  const checkError = error => {
+    expect(error.name).toMatch(/JSONError/);
+  };
 
-      const startDir = absolutePath('a/b');
-      const search = sync =>
-        cosmiconfig('foo', { stopDir: absolutePath('a'), sync }).search(
-          startDir,
-          { ignoreEmpty: false }
-        );
-      const expectedResult = {
-        config: undefined,
-        filepath: absolutePath('a/b/.foorc'),
-        isEmpty: true,
-      };
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      stopDir: absolutePath('a'),
+    })
+      .search(startDir)
+      .catch(checkError);
+  });
 
-      expect.assertions(2);
-      expect(search(true)).toEqual(expectedResult);
-      return expect(search(false)).resolves.toEqual(expectedResult);
-    });
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    expect.hasAssertions();
+    try {
+      cosmiconfig('foo', {
+        stopDir: absolutePath('a'),
+        sync: true,
+      }).search(startDir);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
 
-    it('throws error for invalid YAML in rc file', () => {
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/package.json'):
-            throw { code: 'ENOENT' };
-          case absolutePath('a/b/.foorc'):
-            return 'found: true: broken';
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-      mockReadFile(true, readFile);
-      mockReadFile(false, readFile);
+describe('throws error for invalid JS in .config.js file', () => {
+  const startDir = absolutePath('a/b');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/package.json'):
+      case absolutePath('a/b/.foorc'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/foo.config.js'):
+        return 'module.exports = { found: true: false,';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
 
-      const startDir = absolutePath('a/b');
-      const search = sync =>
-        cosmiconfig('foo', { stopDir: absolutePath('a'), sync }).search(
-          startDir
-        );
+  const checkError = error => {
+    expect(error.name).toBe('SyntaxError');
+  };
 
-      expect.assertions(2);
-      try {
-        search(true);
-      } catch (err) {
-        expect(err.name).toBe('YAMLException');
-      }
-      return search(false).catch(err => {
-        expect(err.name).toBe('YAMLException');
-      });
-    });
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      stopDir: absolutePath('a'),
+    })
+      .search(startDir)
+      .catch(checkError);
+  });
 
-    it('throws error for invalid JSON in rc file with rcStrictJson', () => {
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/package.json'):
-            throw { code: 'ENOENT' };
-          case absolutePath('a/b/.foorc'):
-            return '{ "found": true, }';
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-      mockReadFile(true, readFile);
-      mockReadFile(false, readFile);
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    expect.hasAssertions();
+    try {
+      cosmiconfig('foo', {
+        stopDir: absolutePath('a'),
+        sync: true,
+      }).search(startDir);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
 
-      const startDir = absolutePath('a/b');
-      const search = sync =>
-        cosmiconfig('foo', {
-          stopDir: absolutePath('a'),
-          rcStrictJson: true,
-          sync,
-        }).search(startDir);
+describe('with rcExtensions, throws error for invalid JSON in .foorc.json', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+        return '{ "found": true,, }';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
 
-      expect.assertions(2);
-      expect(() => search(true)).toThrow(/JSON Error/);
-      return search(false).catch(err => {
-        expect(err.message).toMatch(/JSON Error/);
-      });
-    });
+  const checkError = error => {
+    expect(error.message).toMatch(/JSON Error/);
+  };
 
-    it('throws error for invalid package.json', () => {
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/package.json'):
-            return '{ "foo": "bar", }';
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-      mockReadFile(true, readFile);
-      mockReadFile(false, readFile);
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .catch(checkError);
+  });
 
-      const startDir = absolutePath('a/b');
-      const search = sync =>
-        cosmiconfig('foo', { stopDir: absolutePath('a'), sync }).search(
-          startDir
-        );
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    expect.hasAssertions();
+    try {
+      cosmiconfig('foo', {
+        rcExtensions: true,
+        stopDir: absolutePath('.'),
+        sync: true,
+      }).search(startDir);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
 
-      expect.assertions(2);
-      expect(() => search(true)).toThrow(/JSON Error/);
-      return search(false).catch(err => {
-        expect(err.message).toMatch(/JSON Error/);
-      });
-    });
+describe('with rcExtensions, throws error for invalid YAML in .foorc.yml', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+        return 'found: thing: true';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
 
-    it('throws error for invalid JS in .config.js file', () => {
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/package.json'):
-          case absolutePath('a/b/.foorc'):
-            throw { code: 'ENOENT' };
-          case absolutePath('a/b/foo.config.js'):
-            return 'module.exports = { found: true: false,';
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-      mockReadFile(true, readFile);
-      mockReadFile(false, readFile);
+  const checkError = error => {
+    expect(error.name).toBe('YAMLException');
+  };
 
-      const startDir = absolutePath('a/b');
-      const search = sync =>
-        cosmiconfig('foo', { stopDir: absolutePath('a'), sync }).search(
-          startDir
-        );
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .catch(checkError);
+  });
 
-      expect.assertions(2);
-      try {
-        search(true);
-      } catch (err) {
-        expect(err.name).toBe('SyntaxError');
-      }
-      return search(false).catch(err => {
-        expect(err.name).toBe('SyntaxError');
-      });
-    });
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    expect.hasAssertions();
+    try {
+      cosmiconfig('foo', {
+        rcExtensions: true,
+        stopDir: absolutePath('.'),
+        sync: true,
+      }).search(startDir);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
 
-    it('returns an empty config result for empty .config.js file', () => {
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/package.json'):
-          case absolutePath('a/b/.foorc'):
-            throw { code: 'ENOENT' };
-          case absolutePath('a/b/foo.config.js'):
-            return '';
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-      mockReadFile(true, readFile);
-      mockReadFile(false, readFile);
+describe('with rcExtensions, throws error for invalid JS in .foorc.js', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/.foorc.js'):
+        return 'module.exports = found: true };';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
 
-      const startDir = absolutePath('a/b');
-      const search = sync =>
-        cosmiconfig('foo', { stopDir: absolutePath('a'), sync }).search(
-          startDir,
-          { ignoreEmpty: false }
-        );
-      const expectedResult = {
-        config: undefined,
-        filepath: absolutePath('a/b/foo.config.js'),
-        isEmpty: true,
-      };
+  const checkError = error => {
+    expect(error.name).toBe('SyntaxError');
+  };
 
-      expect.assertions(2);
-      expect(search(true)).toEqual(expectedResult);
-      return expect(search(false)).resolves.toEqual(expectedResult);
-    });
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .catch(checkError);
+  });
 
-    describe('with rcExtensions', () => {
-      const startDir = absolutePath('a/b/c/d/e/f');
-      const search = options => {
-        const searchOptions =
-          options.ignoreEmpty != null
-            ? { ignoreEmpty: options.ignoreEmpty }
-            : {};
-
-        return cosmiconfig('foo', {
-          stopDir: absolutePath('.'),
-          rcExtensions: true,
-          sync: options.sync,
-        }).search(startDir, searchOptions);
-      };
-      it('throws error for invalid JSON in .foorc.json', () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/f/.foorc.json'):
-              return '{ "found": true,, }';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        mockReadFile(true, readFile);
-        mockReadFile(false, readFile);
-
-        expect.assertions(2);
-        expect(() => search({ sync: true })).toThrow(/JSON Error/);
-        return search({ sync: false }).catch(err => {
-          expect(err.message).toMatch(/JSON Error/);
-        });
-      });
-
-      it('throws error for invalid YAML in .foorc.yml', () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/f/.foorc.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
-              // This proves the default 'ignoreEmpty' skips over these files as expected
-              return '';
-            case absolutePath('a/b/c/d/e/f/.foorc.yml'):
-              return 'found: thing: true';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        mockReadFile(true, readFile);
-        mockReadFile(false, readFile);
-
-        expect.assertions(2);
-        try {
-          search({ sync: true });
-        } catch (err) {
-          expect(err.name).toBe('YAMLException');
-        }
-        return search({ sync: false }).catch(err => {
-          expect(err.name).toBe('YAMLException');
-        });
-      });
-
-      it('throws error for invalid JS in .foorc.js', () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-            case absolutePath('a/b/c/d/e/f/.foorc.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yml'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/f/.foorc.js'):
-              return 'module.exports = found: true };';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        mockReadFile(true, readFile);
-        mockReadFile(false, readFile);
-
-        expect.assertions(2);
-        try {
-          search({ sync: true });
-        } catch (err) {
-          expect(err.name).toBe('SyntaxError');
-        }
-        return search({ sync: false }).catch(err => {
-          expect(err.name).toBe('SyntaxError');
-        });
-      });
-
-      it('returns an empty config result for an empty json', () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yml'):
-            case absolutePath('a/b/c/d/e/f/.foorc.js'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/f/.foorc.json'):
-              return '';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        mockReadFile(true, readFile);
-        mockReadFile(false, readFile);
-
-        expect.assertions(2);
-
-        const expectedResult = {
-          config: undefined,
-          filepath: absolutePath('a/b/c/d/e/f/.foorc.json'),
-          isEmpty: true,
-        };
-        expect(search({ ignoreEmpty: false, sync: true })).toEqual(
-          expectedResult
-        );
-        return expect(
-          search({ ignoreEmpty: false, sync: false })
-        ).resolves.toEqual(expectedResult);
-      });
-
-      it('returns an empty config result for empty yaml', () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-            case absolutePath('a/b/c/d/e/f/.foorc.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yml'):
-            case absolutePath('a/b/c/d/e/f/.foorc.js'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
-              return '';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        mockReadFile(true, readFile);
-        mockReadFile(false, readFile);
-
-        expect.assertions(2);
-
-        const expectedResult = {
-          config: undefined,
-          filepath: absolutePath('a/b/c/d/e/f/.foorc.yaml'),
-          isEmpty: true,
-        };
-        expect(search({ ignoreEmpty: false, sync: true })).toEqual(
-          expectedResult
-        );
-        return expect(
-          search({ ignoreEmpty: false, sync: false })
-        ).resolves.toEqual(expectedResult);
-      });
-
-      it('returns an empty config result for empty js', () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-            case absolutePath('a/b/c/d/e/f/.foorc.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yml'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/f/.foorc.js'):
-              return '';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        mockReadFile(true, readFile);
-        mockReadFile(false, readFile);
-
-        expect.assertions(2);
-
-        const expectedResult = {
-          config: undefined,
-          filepath: absolutePath('a/b/c/d/e/f/.foorc.js'),
-          isEmpty: true,
-        };
-        expect(search({ ignoreEmpty: false, sync: true })).toEqual(
-          expectedResult
-        );
-        return expect(
-          search({ ignoreEmpty: false, sync: false })
-        ).resolves.toEqual(expectedResult);
-      });
-    });
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    expect.hasAssertions();
+    try {
+      cosmiconfig('foo', {
+        rcExtensions: true,
+        stopDir: absolutePath('.'),
+        sync: true,
+      }).search(startDir);
+    } catch (error) {
+      checkError(error);
+    }
   });
 });

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -158,6 +158,7 @@ describe('throws error for invalid YAML in rc file', () => {
 
   test('async', () => {
     mockReadFile(false, readFile);
+    expect.hasAssertions();
     return cosmiconfig('foo', { stopDir: absolutePath('a') })
       .search(startDir)
       .catch(checkError);
@@ -195,6 +196,7 @@ describe('throws error for invalid JSON in rc file with rcStrictJson', () => {
 
   test('async', () => {
     mockReadFile(false, readFile);
+    expect.hasAssertions();
     return cosmiconfig('foo', {
       rcStrictJson: true,
       stopDir: absolutePath('a'),
@@ -235,6 +237,7 @@ describe('throws error for invalid package.json', () => {
 
   test('async', () => {
     mockReadFile(false, readFile);
+    expect.hasAssertions();
     return cosmiconfig('foo', {
       stopDir: absolutePath('a'),
     })
@@ -276,6 +279,7 @@ describe('throws error for invalid JS in .config.js file', () => {
 
   test('async', () => {
     mockReadFile(false, readFile);
+    expect.hasAssertions();
     return cosmiconfig('foo', {
       stopDir: absolutePath('a'),
     })
@@ -317,6 +321,7 @@ describe('with rcExtensions, throws error for invalid JSON in .foorc.json', () =
 
   test('async', () => {
     mockReadFile(false, readFile);
+    expect.hasAssertions();
     return cosmiconfig('foo', {
       rcExtensions: true,
       stopDir: absolutePath('.'),
@@ -362,6 +367,7 @@ describe('with rcExtensions, throws error for invalid YAML in .foorc.yml', () =>
 
   test('async', () => {
     mockReadFile(false, readFile);
+    expect.hasAssertions();
     return cosmiconfig('foo', {
       rcExtensions: true,
       stopDir: absolutePath('.'),
@@ -408,6 +414,7 @@ describe('with rcExtensions, throws error for invalid JS in .foorc.js', () => {
 
   test('async', () => {
     mockReadFile(false, readFile);
+    expect.hasAssertions();
     return cosmiconfig('foo', {
       rcExtensions: true,
       stopDir: absolutePath('.'),

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -430,3 +430,218 @@ describe('with rcExtensions, throws error for invalid JS in .foorc.js', () => {
     }
   });
 });
+
+describe('with ignoreEmpty: false, returns an empty config result for an empty rc file', () => {
+  const startDir = absolutePath('a/b');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/package.json'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/.foorc'):
+        return '';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = result => {
+    expect(result).toEqual({
+      config: undefined,
+      filepath: absolutePath('a/b/.foorc'),
+      isEmpty: true,
+    });
+  };
+
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', { stopDir: absolutePath('a') })
+      .search(startDir, { ignoreEmpty: false })
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      stopDir: absolutePath('a'),
+      sync: true,
+    }).search(startDir, { ignoreEmpty: false });
+    checkResult(result);
+  });
+});
+
+describe('with ignoreEmpty: false, returns an empty config result for an empty .config.js file', () => {
+  const startDir = absolutePath('a/b');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/package.json'):
+      case absolutePath('a/b/.foorc'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/foo.config.js'):
+        return '';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = result => {
+    expect(result).toEqual({
+      config: undefined,
+      filepath: absolutePath('a/b/foo.config.js'),
+      isEmpty: true,
+    });
+  };
+
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', { stopDir: absolutePath('a') })
+      .search(startDir, { ignoreEmpty: false })
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      stopDir: absolutePath('a'),
+      sync: true,
+    }).search(startDir, { ignoreEmpty: false });
+    checkResult(result);
+  });
+});
+
+describe('with ignoreEmtpy and rcExtensions, returns an empty config result for an empty .json rc file', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.js'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+        return '';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = result => {
+    expect(result).toEqual({
+      config: undefined,
+      filepath: absolutePath('a/b/c/d/e/f/.foorc.json'),
+      isEmpty: true,
+    });
+  };
+
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('a'),
+    })
+      .search(startDir, { ignoreEmpty: false })
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('a'),
+      sync: true,
+    }).search(startDir, { ignoreEmpty: false });
+    checkResult(result);
+  });
+});
+
+describe('with ignoreEmtpy and rcExtensions, returns an empty config result for an empty .yaml rc file', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.js'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+        return '';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = result => {
+    expect(result).toEqual({
+      config: undefined,
+      filepath: absolutePath('a/b/c/d/e/f/.foorc.yaml'),
+      isEmpty: true,
+    });
+  };
+
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('a'),
+    })
+      .search(startDir, { ignoreEmpty: false })
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('a'),
+      sync: true,
+    }).search(startDir, { ignoreEmpty: false });
+    checkResult(result);
+  });
+});
+
+describe('with ignoreEmtpy and rcExtensions, returns an empty config result for an empty .js rc file', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/.foorc.js'):
+        return '';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = result => {
+    expect(result).toEqual({
+      config: undefined,
+      filepath: absolutePath('a/b/c/d/e/f/.foorc.js'),
+      isEmpty: true,
+    });
+  };
+
+  test('async', () => {
+    mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('a'),
+    })
+      .search(startDir, { ignoreEmpty: false })
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('a'),
+      sync: true,
+    }).search(startDir, { ignoreEmpty: false });
+    checkResult(result);
+  });
+});

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -13,6 +13,7 @@ describe('throws error if defined file does not exist', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .catch(checkError);
@@ -35,6 +36,7 @@ describe('throws error if defined JSON file has syntax error', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .catch(checkError);
@@ -57,6 +59,7 @@ describe('throws error if defined YAML file has syntax error', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .catch(checkError);
@@ -79,6 +82,7 @@ describe('throws error if defined JS file has syntax error', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .catch(checkError);
@@ -105,6 +109,7 @@ describe('returns an empty config result for empty file, format JS', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .then(checkResult);
@@ -127,6 +132,7 @@ describe('returns an empty config result for empty file, format JSON', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .then(checkResult);
@@ -149,6 +155,7 @@ describe('returns an empty config result for empty file, format YAML', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .then(checkResult);
@@ -167,6 +174,7 @@ describe('throws error if defined JSON file has unknown extension', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .catch(checkError);
@@ -189,6 +197,7 @@ describe('throws error if defined YAML file has unknown extension', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .catch(checkError);
@@ -211,6 +220,7 @@ describe('throws error if defined JS file has unknown extension', () => {
   };
 
   test('async', () => {
+    expect.hasAssertions();
     return cosmiconfig(null)
       .load(file)
       .catch(checkError);

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -104,8 +104,8 @@ describe('returns an empty config result for empty file, format JS', () => {
     expect(result).toEqual({
       config: undefined,
       filepath: file,
-      isEmpty: true
-    })
+      isEmpty: true,
+    });
   };
 
   test('async', () => {
@@ -127,8 +127,8 @@ describe('returns an empty config result for empty file, format JSON', () => {
     expect(result).toEqual({
       config: undefined,
       filepath: file,
-      isEmpty: true
-    })
+      isEmpty: true,
+    });
   };
 
   test('async', () => {
@@ -150,8 +150,8 @@ describe('returns an empty config result for empty file, format YAML', () => {
     expect(result).toEqual({
       config: undefined,
       filepath: file,
-      isEmpty: true
-    })
+      isEmpty: true,
+    });
   };
 
   test('async', () => {
@@ -244,11 +244,33 @@ test('throws error if configPath is package.json and packageProp is false', () =
   ).toThrow(/Please specify the packageProp option/);
 });
 
-it('in async mode, rejects if configPath is package.json and packageProp is false', () => {
+test('in async mode, rejects if configPath is package.json and packageProp is false', () => {
   expect.assertions(1);
   return cosmiconfig('foo', { packageProp: false })
     .load(path.join(__dirname, 'fixtures/package.json'))
     .catch(error => {
       expect(error.message).toContain('Please specify the packageProp option');
     });
+});
+
+describe('throws an error if no configPath was specified and load is called without an argument', () => {
+  const checkError = error => {
+    expect(error.message).toMatch(/^configPath must be a nonempty string/);
+  };
+
+  test('async', () => {
+    expect.hasAssertions();
+    return cosmiconfig('not_exist_rc_name')
+      .load()
+      .catch(checkError);
+  });
+
+  test('sync', () => {
+    expect.hasAssertions();
+    try {
+      cosmiconfig('not_exist_rc_name', { sync: true }).load();
+    } catch (error) {
+      checkError(error);
+    }
+  });
 });

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -4,220 +4,241 @@ const path = require('path');
 const util = require('./util');
 const cosmiconfig = require('../src');
 
-const configFileLoader = util.configFileLoader;
+const absolutePath = util.absolutePath;
 
-const expectForFormat = {
-  json(err) {
-    expect(err.message).toMatch(/JSON Error/);
-  },
-  yaml(err) {
-    expect(err.name).toBe('YAMLException');
-  },
-  js(err) {
-    expect(err.name).toBe('ReferenceError');
-  },
-};
-
-function makeSyntaxErrWithoutKnownExtnameTest(format) {
-  const file = `fixtures/foo-invalid-${format}`;
-
-  return () => {
-    expect.assertions(2);
-    expect(() => configFileLoader({ sync: true }, file)).toThrow(
-      /^Failed to parse/
-    );
-
-    return configFileLoader(null, file).catch(err => {
-      expect(err.message).toMatch(/^Failed to parse/);
-    });
+describe('throws error if defined file does not exist', () => {
+  const file = absolutePath('does/not/exist');
+  const checkError = error => {
+    expect(error.code).toBe('ENOENT');
   };
-}
 
-function makeSyntaxErrTest(format) {
-  const file = `fixtures/foo-invalid.${format}`;
-
-  return () => {
-    expect.assertions(2);
-    try {
-      configFileLoader({ sync: true }, file);
-    } catch (err) {
-      expectForFormat[format](err);
-    }
-
-    return configFileLoader(null, file).catch(expectForFormat[format]);
-  };
-}
-
-function makeSyntaxErrWithFormatTest(format) {
-  const file = `fixtures/foo-invalid.${format}`;
-
-  return () => {
-    expect.assertions(2);
-    try {
-      configFileLoader({ sync: true, format }, file);
-    } catch (err) {
-      expectForFormat[format](err);
-    }
-
-    return configFileLoader({ format }, file).catch(expectForFormat[format]);
-  };
-}
-
-function makeEmptyFileTest(fileFormat, withFormat) {
-  const format = withFormat === true ? fileFormat : undefined;
-  const file = `fixtures/foo-empty.${fileFormat}`;
-  return () => {
-    expect.assertions(2);
-    const expectedResult = {
-      config: undefined,
-      filepath: path.join(__dirname, file),
-      isEmpty: true,
-    };
-
-    expect(configFileLoader({ sync: true, format }, file)).toEqual(
-      expectedResult
-    );
-
-    return expect(configFileLoader({ format }, file)).resolves.toEqual(
-      expectedResult
-    );
-  };
-}
-
-describe('cosmiconfig', () => {
-  describe('search from file', () => {
-    it('throws error if defined file does not exist', () => {
-      expect.assertions(2);
-      try {
-        configFileLoader({ sync: true }, 'does/not/exist');
-      } catch (err) {
-        expect(err.code).toBe('ENOENT');
-      }
-
-      return configFileLoader(null, 'does/not/exist').catch(err => {
-        expect(err.code).toBe('ENOENT');
-      });
-    });
-
-    describe('without expected format', () => {
-      it(
-        'throws error if defined JSON file has syntax error',
-        makeSyntaxErrTest('json')
-      );
-
-      it(
-        'throws error if defined YAML file has syntax error',
-        makeSyntaxErrTest('yaml')
-      );
-
-      it(
-        'throws error if defined JS file has syntax error',
-        makeSyntaxErrTest('js')
-      );
-
-      it(
-        'returns an empty config result for an empty file, format JS',
-        makeEmptyFileTest('js')
-      );
-
-      it(
-        'returns an empty config result for an empty file, format JSON',
-        makeEmptyFileTest('json')
-      );
-
-      it(
-        'returns an empty config result for an empty file, format YAML',
-        makeEmptyFileTest('yaml')
-      );
-    });
-
-    describe('with expected format', () => {
-      it(
-        'throws error if defined JSON file has syntax error',
-        makeSyntaxErrWithFormatTest('json')
-      );
-
-      it(
-        'throws error if defined YAML file has syntax error',
-        makeSyntaxErrWithFormatTest('yaml')
-      );
-
-      it(
-        'throws error if defined JS file has syntax error',
-        makeSyntaxErrWithFormatTest('js')
-      );
-
-      it(
-        'returns an empty config result for an empty file, format JS',
-        makeEmptyFileTest('js', true)
-      );
-
-      it(
-        'returns an empty config result for an empty file, format JSON',
-        makeEmptyFileTest('json', true)
-      );
-
-      it(
-        'returns an empty config result for an empty file, format YAML',
-        makeEmptyFileTest('yaml', true)
-      );
-    });
-
-    describe('with unknown extname', () => {
-      it(
-        'throws error if defined JSON file has syntax error',
-        makeSyntaxErrWithoutKnownExtnameTest('json')
-      );
-
-      it(
-        'throws error if defined YAML file has syntax error',
-        makeSyntaxErrWithoutKnownExtnameTest('yaml')
-      );
-
-      it(
-        'throws error if defined JS file has syntax error',
-        makeSyntaxErrWithoutKnownExtnameTest('js')
-      );
-    });
-
-    it('returns null if configuration file does not exist', () => {
-      const load = sync =>
-        cosmiconfig('not_exist_rc_name', { sync }).search('.');
-
-      expect.assertions(2);
-      expect(load(true)).toBe(null);
-      return expect(load(false)).resolves.toBe(null);
-    });
-
-    it('in sync mode, throws error if configPath is package.json and packageProp is false', () => {
-      expect(() =>
-        cosmiconfig('foo', { sync: true, packageProp: false }).load(
-          path.join(__dirname, 'fixtures/package.json')
-        )
-      ).toThrow(/Please specify the packageProp option/);
-    });
-
-    it('in async mode, rejects if configPath is package.json and packageProp is false', () => {
-      expect.assertions(1);
-      return cosmiconfig('foo', { packageProp: false })
-        .load(path.join(__dirname, 'fixtures/package.json'))
-        .catch(error => {
-          expect(error.message).toContain(
-            'Please specify the packageProp option'
-          );
-        });
-    });
-
-    it('throws an error if no configPath was specified', () => {
-      const load = sync => cosmiconfig('not_exist_rc_name', { sync }).load();
-      const errorRegex = /^configPath must be a nonempty string/;
-
-      expect.assertions(2);
-      expect(() => load(true)).toThrow(errorRegex);
-
-      return load(false).catch(error => {
-        expect(error.message).toMatch(errorRegex);
-      });
-    });
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .catch(checkError);
   });
+
+  test('sync', () => {
+    expect.hasAssertions();
+    try {
+      cosmiconfig(null, { sync: true }).load(file);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
+
+describe('throws error if defined JSON file has syntax error', () => {
+  const file = absolutePath(`fixtures/foo-invalid.json`);
+  const checkError = error => {
+    expect(error.message).toMatch(/JSON Error/);
+  };
+
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .catch(checkError);
+  });
+
+  test('sync', () => {
+    expect.hasAssertions();
+    try {
+      cosmiconfig(null, { sync: true }).load(file);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
+
+describe('throws error if defined YAML file has syntax error', () => {
+  const file = absolutePath(`fixtures/foo-invalid.yaml`);
+  const checkError = error => {
+    expect(error.name).toBe('YAMLException');
+  };
+
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .catch(checkError);
+  });
+
+  test('sync', () => {
+    expect.hasAssertions();
+    try {
+      cosmiconfig(null, { sync: true }).load(file);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
+
+describe('throws error if defined JS file has syntax error', () => {
+  const file = absolutePath(`fixtures/foo-invalid.js`);
+  const checkError = error => {
+    expect(error.name).toBe('ReferenceError');
+  };
+
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .catch(checkError);
+  });
+
+  test('sync', () => {
+    expect.hasAssertions();
+    try {
+      cosmiconfig(null, { sync: true }).load(file);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
+
+describe('returns an empty config result for empty file, format JS', () => {
+  const file = absolutePath(`fixtures/foo-empty.js`);
+  const checkResult = result => {
+    expect(result).toEqual({
+      config: undefined,
+      filepath: file,
+      isEmpty: true
+    })
+  };
+
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfig(null, { sync: true }).load(file);
+    checkResult(result);
+  });
+});
+
+describe('returns an empty config result for empty file, format JSON', () => {
+  const file = absolutePath(`fixtures/foo-empty.json`);
+  const checkResult = result => {
+    expect(result).toEqual({
+      config: undefined,
+      filepath: file,
+      isEmpty: true
+    })
+  };
+
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfig(null, { sync: true }).load(file);
+    checkResult(result);
+  });
+});
+
+describe('returns an empty config result for empty file, format YAML', () => {
+  const file = absolutePath(`fixtures/foo-empty.yaml`);
+  const checkResult = result => {
+    expect(result).toEqual({
+      config: undefined,
+      filepath: file,
+      isEmpty: true
+    })
+  };
+
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfig(null, { sync: true }).load(file);
+    checkResult(result);
+  });
+});
+
+describe('throws error if defined JSON file has unknown extension', () => {
+  const file = absolutePath(`fixtures/foo-invalid-json`);
+  const checkError = error => {
+    expect(error.message).toMatch(/^Failed to parse/);
+  };
+
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .catch(checkError);
+  });
+
+  test('sync', () => {
+    expect.hasAssertions();
+    try {
+      cosmiconfig(null, { sync: true }).load(file);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
+
+describe('throws error if defined YAML file has unknown extension', () => {
+  const file = absolutePath(`fixtures/foo-invalid-yaml`);
+  const checkError = error => {
+    expect(error.message).toMatch(/^Failed to parse/);
+  };
+
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .catch(checkError);
+  });
+
+  test('sync', () => {
+    expect.hasAssertions();
+    try {
+      cosmiconfig(null, { sync: true }).load(file);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
+
+describe('throws error if defined JS file has unknown extension', () => {
+  const file = absolutePath(`fixtures/foo-invalid-js`);
+  const checkError = error => {
+    expect(error.message).toMatch(/^Failed to parse/);
+  };
+
+  test('async', () => {
+    return cosmiconfig(null)
+      .load(file)
+      .catch(checkError);
+  });
+
+  test('sync', () => {
+    expect.hasAssertions();
+    try {
+      cosmiconfig(null, { sync: true }).load(file);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});
+
+test('throws error if configPath is package.json and packageProp is false', () => {
+  expect(() =>
+    cosmiconfig('foo', { sync: true, packageProp: false }).load(
+      path.join(__dirname, 'fixtures/package.json')
+    )
+  ).toThrow(/Please specify the packageProp option/);
+});
+
+it('in async mode, rejects if configPath is package.json and packageProp is false', () => {
+  expect.assertions(1);
+  return cosmiconfig('foo', { packageProp: false })
+    .load(path.join(__dirname, 'fixtures/package.json'))
+    .catch(error => {
+      expect(error.message).toContain('Please specify the packageProp option');
+    });
 });

--- a/test/resolveDir.test.js
+++ b/test/resolveDir.test.js
@@ -1,54 +1,54 @@
 'use strict';
 
-const util = require('./util');
 const getDirectory = require('../src/getDirectory');
 
-const testFuncsRunner = util.testFuncsRunner;
-const testSyncAndAsync = util.testSyncAndAsync;
+describe('returns the searchPath if it is a directory', () => {
+  const subject = __dirname;
+  const checkResult = result => {
+    expect(result).toBe(subject);
+  };
 
-describe('getDirectory', () => {
-  testSyncAndAsync(
-    'returns the searchPath if it is a directory',
-    sync => () => {
-      expect.hasAssertions();
-      return testFuncsRunner(sync, getDirectory(__dirname, sync), [
-        dir => {
-          expect(dir).toBe(__dirname);
-        },
-      ]);
-    }
-  );
-
-  testSyncAndAsync(
-    'returns the parent directory if it is a file',
-    sync => () => {
-      expect.hasAssertions();
-      return testFuncsRunner(sync, getDirectory(__filename, sync), [
-        dir => {
-          expect(dir).toBe(__dirname);
-        },
-      ]);
-    }
-  );
-
-  it('returns a promise if sync is not true', () => {
-    // Although we explicitly pass `false`, the result will be a promise even
-    // if a value was not passed, because it would be falsy and not exactly
-    // equal to `true`.
-    const res = getDirectory(__dirname, false);
-    expect(res).toBeInstanceOf(Promise);
+  test('async', () => {
+    return getDirectory(subject, false).then(checkResult);
   });
 
-  it('propagates error thrown by is-directory in sync', () => {
-    expect(() => getDirectory(null, true)).toThrowError(
-      'expected filepath to be a string'
-    );
+  test('sync', () => {
+    checkResult(getDirectory(subject, true));
+  });
+});
+
+describe('returns the parent directory if it is a file', () => {
+  const subject = __filename;
+  const checkResult = result => {
+    expect(result).toBe(__dirname);
+  };
+
+  test('async', () => {
+    return getDirectory(subject, false).then(checkResult);
   });
 
-  it('rejects with the error thrown by is-directory in async', () => {
-    expect.hasAssertions();
-    return getDirectory(null, false).catch(err => {
-      expect(err.message).toBe('expected filepath to be a string');
-    });
+  test('sync', () => {
+    checkResult(getDirectory(subject, true));
+  });
+});
+
+test('returns a promise if sync is not true', () => {
+  // Although we explicitly pass `false`, the result will be a promise even
+  // if a value was not passed, because it would be falsy and not exactly
+  // equal to `true`.
+  const res = getDirectory(__dirname, false);
+  expect(res).toBeInstanceOf(Promise);
+});
+
+test('propagates error thrown by is-directory in sync', () => {
+  expect(() => getDirectory(null, true)).toThrowError(
+    'expected filepath to be a string'
+  );
+});
+
+test('rejects with the error thrown by is-directory in async', () => {
+  expect.hasAssertions();
+  return getDirectory(null, false).catch(err => {
+    expect(err.message).toBe('expected filepath to be a string');
   });
 });

--- a/test/successful-directories.test.js
+++ b/test/successful-directories.test.js
@@ -9,8 +9,6 @@ const cosmiconfig = require('../src');
 
 const absolutePath = util.absolutePath;
 const mockReadFile = util.mockReadFile;
-const testFuncsRunner = util.testFuncsRunner;
-const testSyncAndAsync = util.testSyncAndAsync;
 
 beforeAll(() => {
   util.mockStatIsDirectory(true);
@@ -31,492 +29,553 @@ afterAll(() => {
   jest.resetAllMocks();
 });
 
-describe('cosmiconfig', () => {
-  describe('search from directory', () => {
-    const search = (sync, startDir) =>
-      cosmiconfig('foo', { stopDir: absolutePath('.'), sync }).search(startDir);
+describe('finds rc file in third searched dir, with a package.json lacking prop', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/foo.config.js'):
+      case absolutePath('a/b/c/d/e/package.json'):
+      case absolutePath('a/b/c/d/e/.foorc'):
+      case absolutePath('a/b/c/d/e/foo.config.js'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/package.json'):
+        return '{ "false": "hope" }';
+      case absolutePath('a/b/c/d/.foorc'):
+        return '{ "found": true }';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
 
-    testSyncAndAsync(
-      'finds rc file in third searched dir, with a package.json lacking prop',
-      sync => () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-            case absolutePath('a/b/c/d/e/f/foo.config.js'):
-            case absolutePath('a/b/c/d/e/package.json'):
-            case absolutePath('a/b/c/d/e/.foorc'):
-            case absolutePath('a/b/c/d/e/foo.config.js'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/package.json'):
-              return '{ "false": "hope" }';
-            case absolutePath('a/b/c/d/.foorc'):
-              return '{ "found": true }';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        const readFileMock = mockReadFile(sync, readFile);
-        const startDir = absolutePath('a/b/c/d/e/f');
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/f/.foorc',
+      'a/b/c/d/e/f/foo.config.js',
+      'a/b/c/d/e/package.json',
+      'a/b/c/d/e/.foorc',
+      'a/b/c/d/e/foo.config.js',
+      'a/b/c/d/package.json',
+      'a/b/c/d/.foorc',
+    ]);
 
-        expect.hasAssertions();
-        return testFuncsRunner(sync, search(sync, startDir), [
-          result => {
-            util.assertSearchSequence(readFileMock, [
-              'a/b/c/d/e/f/package.json',
-              'a/b/c/d/e/f/.foorc',
-              'a/b/c/d/e/f/foo.config.js',
-              'a/b/c/d/e/package.json',
-              'a/b/c/d/e/.foorc',
-              'a/b/c/d/e/foo.config.js',
-              'a/b/c/d/package.json',
-              'a/b/c/d/.foorc',
-            ]);
-
-            expect(result).toEqual({
-              config: { found: true },
-              filepath: absolutePath('a/b/c/d/.foorc'),
-            });
-          },
-        ]);
-      }
-    );
-
-    testSyncAndAsync(
-      'finds package.json prop in second searched dir',
-      sync => () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-            case absolutePath('a/b/c/d/e/f/foo.config.js'):
-            case absolutePath('a/b/c/d/e/.foorc'):
-            case absolutePath('a/b/c/d/e/foo.config.js'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/package.json'):
-              return '{ "author": "Todd", "foo": { "found": true } }';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        const readFileMock = mockReadFile(sync, readFile);
-        const startDir = absolutePath('a/b/c/d/e/f');
-
-        expect.hasAssertions();
-        return testFuncsRunner(sync, search(sync, startDir), [
-          result => {
-            util.assertSearchSequence(readFileMock, [
-              'a/b/c/d/e/f/package.json',
-              'a/b/c/d/e/f/.foorc',
-              'a/b/c/d/e/f/foo.config.js',
-              'a/b/c/d/e/package.json',
-            ]);
-
-            expect(result).toEqual({
-              config: { found: true },
-              filepath: absolutePath('a/b/c/d/e/package.json'),
-            });
-          },
-        ]);
-      }
-    );
-
-    testSyncAndAsync('finds JS file in first searched dir', sync => () => {
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/c/d/e/f/package.json'):
-          case absolutePath('a/b/c/d/e/f/.foorc'):
-          case absolutePath('a/b/c/d/e/package.json'):
-          case absolutePath('a/b/c/d/e/.foorc'):
-          case absolutePath('a/b/c/d/e/foo.config.js'):
-            throw { code: 'ENOENT' };
-          case absolutePath('a/b/c/d/e/f/foo.config.js'):
-            return 'module.exports = { found: true };';
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-      const readFileMock = mockReadFile(sync, readFile);
-      const startDir = absolutePath('a/b/c/d/e/f');
-
-      expect.hasAssertions();
-      return testFuncsRunner(sync, search(sync, startDir), [
-        result => {
-          util.assertSearchSequence(readFileMock, [
-            'a/b/c/d/e/f/package.json',
-            'a/b/c/d/e/f/.foorc',
-            'a/b/c/d/e/f/foo.config.js',
-          ]);
-
-          expect(result).toEqual({
-            config: { found: true },
-            filepath: absolutePath('a/b/c/d/e/f/foo.config.js'),
-          });
-        },
-      ]);
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/.foorc'),
     });
+  };
 
-    testSyncAndAsync(
-      'finds package.json in second dir searched, with alternate names',
-      sync => () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.wowza'):
-            case absolutePath('a/b/c/d/e/f/wowzaConfig.js'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/package.json'):
-              return '{ "heeha": { "found": true } }';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        const readFileMock = mockReadFile(sync, readFile);
-        const startDir = absolutePath('a/b/c/d/e/f');
-
-        expect.hasAssertions();
-        return testFuncsRunner(
-          sync,
-          cosmiconfig('foo', {
-            rc: '.wowza',
-            js: 'wowzaConfig.js',
-            packageProp: 'heeha',
-            stopDir: absolutePath('.'),
-            sync,
-          }).search(startDir),
-          [
-            result => {
-              util.assertSearchSequence(readFileMock, [
-                'a/b/c/d/e/f/package.json',
-                'a/b/c/d/e/f/.wowza',
-                'a/b/c/d/e/f/wowzaConfig.js',
-                'a/b/c/d/e/package.json',
-              ]);
-
-              expect(result).toEqual({
-                config: { found: true },
-                filepath: absolutePath('a/b/c/d/e/package.json'),
-              });
-            },
-          ]
-        );
-      }
-    );
-
-    testSyncAndAsync(
-      'finds rc file in third searched dir, skipping packageProp, with rcStrictJson',
-      sync => () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-            case absolutePath('a/b/c/d/e/f/foo.config.js'):
-            case absolutePath('a/b/c/d/e/package.json'):
-            case absolutePath('a/b/c/d/e/.foorc'):
-            case absolutePath('a/b/c/d/e/foo.config.js'):
-            case absolutePath('a/b/c/d/package.json'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/.foorc'):
-              return '{ "found": true }';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        const readFileMock = mockReadFile(sync, readFile);
-        const startDir = absolutePath('a/b/c/d/e/f');
-
-        expect.hasAssertions();
-        return testFuncsRunner(
-          sync,
-          cosmiconfig('foo', {
-            packageProp: false,
-            rcStrictJson: true,
-            stopDir: absolutePath('.'),
-            sync,
-          }).search(startDir),
-          [
-            result => {
-              util.assertSearchSequence(readFileMock, [
-                'a/b/c/d/e/f/.foorc',
-                'a/b/c/d/e/f/foo.config.js',
-                'a/b/c/d/e/.foorc',
-                'a/b/c/d/e/foo.config.js',
-                'a/b/c/d/.foorc',
-              ]);
-
-              expect(result).toEqual({
-                config: { found: true },
-                filepath: absolutePath('a/b/c/d/.foorc'),
-              });
-            },
-          ]
-        );
-      }
-    );
-
-    testSyncAndAsync(
-      'finds rc file in third searched dir, skipping packageProp, with rcStrictJson',
-      sync => () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-            case absolutePath('a/b/c/d/e/f/foo.config.js'):
-            case absolutePath('a/b/c/d/e/.foorc'):
-            case absolutePath('a/b/c/d/e/foo.config.js'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/package.json'):
-              return '{ "author": "Todd", "foo": { "found": true } }';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        const readFileMock = mockReadFile(sync, readFile);
-        const startDir = absolutePath('a/b/c/d/e/f');
-
-        expect.hasAssertions();
-        return testFuncsRunner(
-          sync,
-          cosmiconfig('foo', {
-            js: false,
-            rc: false,
-            stopDir: absolutePath('.'),
-            sync,
-          }).search(startDir),
-          [
-            result => {
-              util.assertSearchSequence(readFileMock, [
-                'a/b/c/d/e/f/package.json',
-                'a/b/c/d/e/package.json',
-              ]);
-
-              expect(result).toEqual({
-                config: { found: true },
-                filepath: absolutePath('a/b/c/d/e/package.json'),
-              });
-            },
-          ]
-        );
-      }
-    );
-
-    testSyncAndAsync('finds JS file traversing from cwd', sync => () => {
-      const originalCwd = process.cwd;
-      expect.hasAssertions();
-
-      function readFile(searchPath) {
-        switch (searchPath) {
-          case absolutePath('a/b/c/d/e/f/package.json'):
-          case absolutePath('a/b/c/d/e/f/.foorc'):
-          case absolutePath('a/b/c/d/e/f/foo.config.js'):
-          case absolutePath('a/b/c/d/e/package.json'):
-          case absolutePath('a/b/c/d/e/.foorc'):
-            throw { code: 'ENOENT' };
-          case absolutePath('a/b/c/d/e/foo.config.js'):
-            return 'module.exports = { found: true };';
-          default:
-            throw new Error(`irrelevant path ${searchPath}`);
-        }
-      }
-
-      try {
-        const readFileMock = mockReadFile(sync, readFile);
-        process.cwd = jest.fn(() => absolutePath('a/b/c/d/e/f'));
-
-        return testFuncsRunner(sync, search(sync), [
-          result => {
-            util.assertSearchSequence(readFileMock, [
-              'a/b/c/d/e/f/package.json',
-              'a/b/c/d/e/f/.foorc',
-              'a/b/c/d/e/f/foo.config.js',
-              'a/b/c/d/e/package.json',
-              'a/b/c/d/e/.foorc',
-              'a/b/c/d/e/foo.config.js',
-            ]);
-
-            expect(result).toEqual({
-              config: { found: true },
-              filepath: absolutePath('a/b/c/d/e/foo.config.js'),
-            });
-          },
-        ]);
-      } finally {
-        process.cwd = originalCwd;
-      }
-    });
-
-    // RC file with specified extension
-
-    describe('with rcExtensions', () => {
-      const search = (sync, startDir) =>
-        cosmiconfig('foo', {
-          stopDir: absolutePath('.'),
-          rcExtensions: true,
-          sync,
-        }).search(startDir);
-
-      testSyncAndAsync(
-        'finds .foorc.json in second searched dir',
-        sync => () => {
-          function readFile(searchPath) {
-            switch (searchPath) {
-              case absolutePath('a/b/c/d/e/f/package.json'):
-              case absolutePath('a/b/c/d/e/f/.foorc'):
-              case absolutePath('a/b/c/d/e/f/.foorc.json'):
-              case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
-              case absolutePath('a/b/c/d/e/f/.foorc.yml'):
-              case absolutePath('a/b/c/d/e/f/.foorc.js'):
-              case absolutePath('a/b/c/d/e/f/foo.config.js'):
-              case absolutePath('a/b/c/d/e/package.json'):
-              case absolutePath('a/b/c/d/e/.foorc'):
-                throw { code: 'ENOENT' };
-              case absolutePath('a/b/c/d/e/.foorc.json'):
-                return '{ "found": true }';
-              default:
-                throw new Error(`irrelevant path ${searchPath}`);
-            }
-          }
-          const readFileMock = mockReadFile(sync, readFile);
-          const startDir = absolutePath('a/b/c/d/e/f');
-
-          expect.hasAssertions();
-          return testFuncsRunner(sync, search(sync, startDir), [
-            result => {
-              util.assertSearchSequence(readFileMock, [
-                'a/b/c/d/e/f/package.json',
-                'a/b/c/d/e/f/.foorc',
-                'a/b/c/d/e/f/.foorc.json',
-                'a/b/c/d/e/f/.foorc.yaml',
-                'a/b/c/d/e/f/.foorc.yml',
-                'a/b/c/d/e/f/.foorc.js',
-                'a/b/c/d/e/f/foo.config.js',
-                'a/b/c/d/e/package.json',
-                'a/b/c/d/e/.foorc',
-                'a/b/c/d/e/.foorc.json',
-              ]);
-
-              expect(result).toEqual({
-                config: { found: true },
-                filepath: absolutePath('a/b/c/d/e/.foorc.json'),
-              });
-            },
-          ]);
-        }
-      );
-
-      testSyncAndAsync(
-        'finds .foorc.yaml in first searched dir',
-        sync => () => {
-          function readFile(searchPath) {
-            switch (searchPath) {
-              case absolutePath('a/b/c/d/e/f/package.json'):
-              case absolutePath('a/b/c/d/e/f/.foorc'):
-              case absolutePath('a/b/c/d/e/f/.foorc.json'):
-                throw { code: 'ENOENT' };
-              case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
-                return 'found: true';
-              default:
-                throw new Error(`irrelevant path ${searchPath}`);
-            }
-          }
-          const readFileMock = mockReadFile(sync, readFile);
-          const startDir = absolutePath('a/b/c/d/e/f');
-
-          expect.hasAssertions();
-          return testFuncsRunner(sync, search(sync, startDir), [
-            result => {
-              util.assertSearchSequence(readFileMock, [
-                'a/b/c/d/e/f/package.json',
-                'a/b/c/d/e/f/.foorc',
-                'a/b/c/d/e/f/.foorc.json',
-                'a/b/c/d/e/f/.foorc.yaml',
-              ]);
-
-              expect(result).toEqual({
-                config: { found: true },
-                filepath: absolutePath('a/b/c/d/e/f/.foorc.yaml'),
-              });
-            },
-          ]);
-        }
-      );
-
-      testSyncAndAsync(
-        'finds .foorc.yaml in first searched dir',
-        sync => () => {
-          function readFile(searchPath) {
-            switch (searchPath) {
-              case absolutePath('a/b/c/d/e/f/package.json'):
-              case absolutePath('a/b/c/d/e/f/.foorc'):
-              case absolutePath('a/b/c/d/e/f/.foorc.json'):
-              case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
-                throw { code: 'ENOENT' };
-              case absolutePath('a/b/c/d/e/f/.foorc.yml'):
-                return 'found: true';
-              default:
-                throw new Error(`irrelevant path ${searchPath}`);
-            }
-          }
-          const readFileMock = mockReadFile(sync, readFile);
-          const startDir = absolutePath('a/b/c/d/e/f');
-
-          expect.hasAssertions();
-          return testFuncsRunner(sync, search(sync, startDir), [
-            result => {
-              util.assertSearchSequence(readFileMock, [
-                'a/b/c/d/e/f/package.json',
-                'a/b/c/d/e/f/.foorc',
-                'a/b/c/d/e/f/.foorc.json',
-                'a/b/c/d/e/f/.foorc.yaml',
-                'a/b/c/d/e/f/.foorc.yml',
-              ]);
-
-              expect(result).toEqual({
-                config: { found: true },
-                filepath: absolutePath('a/b/c/d/e/f/.foorc.yml'),
-              });
-            },
-          ]);
-        }
-      );
-
-      testSyncAndAsync('finds .foorc.js in first searched dir', sync => () => {
-        function readFile(searchPath) {
-          switch (searchPath) {
-            case absolutePath('a/b/c/d/e/f/package.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc'):
-            case absolutePath('a/b/c/d/e/f/.foorc.json'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
-            case absolutePath('a/b/c/d/e/f/.foorc.yml'):
-              throw { code: 'ENOENT' };
-            case absolutePath('a/b/c/d/e/f/.foorc.js'):
-              return 'module.exports = { found: true };';
-            default:
-              throw new Error(`irrelevant path ${searchPath}`);
-          }
-        }
-        const readFileMock = mockReadFile(sync, readFile);
-        const startDir = absolutePath('a/b/c/d/e/f');
-
-        expect.hasAssertions();
-        return testFuncsRunner(sync, search(sync, startDir), [
-          result => {
-            util.assertSearchSequence(readFileMock, [
-              'a/b/c/d/e/f/package.json',
-              'a/b/c/d/e/f/.foorc',
-              'a/b/c/d/e/f/.foorc.json',
-              'a/b/c/d/e/f/.foorc.yaml',
-              'a/b/c/d/e/f/.foorc.yml',
-              'a/b/c/d/e/f/.foorc.js',
-            ]);
-
-            expect(result).toEqual({
-              config: { found: true },
-              filepath: absolutePath('a/b/c/d/e/f/.foorc.js'),
-            });
-          },
-        ]);
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', { stopDir: absolutePath('.') })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
       });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('finds package.json prop in second searched dir', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/foo.config.js'):
+      case absolutePath('a/b/c/d/e/.foorc'):
+      case absolutePath('a/b/c/d/e/foo.config.js'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/package.json'):
+        return '{ "author": "Todd", "foo": { "found": true } }';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/f/.foorc',
+      'a/b/c/d/e/f/foo.config.js',
+      'a/b/c/d/e/package.json',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/e/package.json'),
     });
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', { stopDir: absolutePath('.') })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('finds JS file in first searched dir', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/package.json'):
+      case absolutePath('a/b/c/d/e/.foorc'):
+      case absolutePath('a/b/c/d/e/foo.config.js'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/foo.config.js'):
+        return 'module.exports = { found: true };';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/f/.foorc',
+      'a/b/c/d/e/f/foo.config.js',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/e/f/foo.config.js'),
+    });
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', { stopDir: absolutePath('.') })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('finds package.json in second dir searched, with alternate names', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.wowza'):
+      case absolutePath('a/b/c/d/e/f/wowzaConfig.js'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/package.json'):
+        return '{ "heeha": { "found": true } }';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/f/.wowza',
+      'a/b/c/d/e/f/wowzaConfig.js',
+      'a/b/c/d/e/package.json',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/e/package.json'),
+    });
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rc: '.wowza',
+      js: 'wowzaConfig.js',
+      packageProp: 'heeha',
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      rc: '.wowza',
+      js: 'wowzaConfig.js',
+      packageProp: 'heeha',
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('finds rc file in third searched dir, skipping packageProp, with rcStrictJson', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/foo.config.js'):
+      case absolutePath('a/b/c/d/e/package.json'):
+      case absolutePath('a/b/c/d/e/.foorc'):
+      case absolutePath('a/b/c/d/e/foo.config.js'):
+      case absolutePath('a/b/c/d/package.json'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/.foorc'):
+        return '{ "found": true }';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/.foorc',
+      'a/b/c/d/e/f/foo.config.js',
+      'a/b/c/d/e/.foorc',
+      'a/b/c/d/e/foo.config.js',
+      'a/b/c/d/.foorc',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/.foorc'),
+    });
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      packageProp: false,
+      rcStrictJson: true,
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      packageProp: false,
+      rcStrictJson: true,
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('finds rc file in third searched dir, skipping JS and RC files, with rcStrictJson', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/foo.config.js'):
+      case absolutePath('a/b/c/d/e/.foorc'):
+      case absolutePath('a/b/c/d/e/foo.config.js'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/package.json'):
+        return '{ "author": "Todd", "foo": { "found": true } }';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/package.json',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/e/package.json'),
+    });
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      js: false,
+      rc: false,
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      js: false,
+      rc: false,
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('with rcExtensions, finds .foorc.json in second searched dir', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.js'):
+      case absolutePath('a/b/c/d/e/f/foo.config.js'):
+      case absolutePath('a/b/c/d/e/package.json'):
+      case absolutePath('a/b/c/d/e/.foorc'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/.foorc.json'):
+        return '{ "found": true }';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/f/.foorc',
+      'a/b/c/d/e/f/.foorc.json',
+      'a/b/c/d/e/f/.foorc.yaml',
+      'a/b/c/d/e/f/.foorc.yml',
+      'a/b/c/d/e/f/.foorc.js',
+      'a/b/c/d/e/f/foo.config.js',
+      'a/b/c/d/e/package.json',
+      'a/b/c/d/e/.foorc',
+      'a/b/c/d/e/.foorc.json',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/e/.foorc.json'),
+    });
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('with rcExtensions, finds .foorc.yaml in first searched dir', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+        return 'found: true';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/f/.foorc',
+      'a/b/c/d/e/f/.foorc.json',
+      'a/b/c/d/e/f/.foorc.yaml',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/e/f/.foorc.yaml'),
+    });
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('with rcExtensions, finds .foorc.yml in first searched dir', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+        return 'found: true';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/f/.foorc',
+      'a/b/c/d/e/f/.foorc.json',
+      'a/b/c/d/e/f/.foorc.yaml',
+      'a/b/c/d/e/f/.foorc.yml',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/e/f/.foorc.yml'),
+    });
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
+  });
+});
+
+describe('with rcExtensions, finds .foorc.js in first searched dir', () => {
+  const startDir = absolutePath('a/b/c/d/e/f');
+  const readFile = searchPath => {
+    switch (searchPath) {
+      case absolutePath('a/b/c/d/e/f/package.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc'):
+      case absolutePath('a/b/c/d/e/f/.foorc.json'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yaml'):
+      case absolutePath('a/b/c/d/e/f/.foorc.yml'):
+        throw { code: 'ENOENT' };
+      case absolutePath('a/b/c/d/e/f/.foorc.js'):
+        return 'module.exports = { found: true };';
+      default:
+        throw new Error(`irrelevant path ${searchPath}`);
+    }
+  };
+
+  const checkResult = (readFileMock, result) => {
+    util.assertSearchSequence(readFileMock, [
+      'a/b/c/d/e/f/package.json',
+      'a/b/c/d/e/f/.foorc',
+      'a/b/c/d/e/f/.foorc.json',
+      'a/b/c/d/e/f/.foorc.yaml',
+      'a/b/c/d/e/f/.foorc.yml',
+      'a/b/c/d/e/f/.foorc.js',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: absolutePath('a/b/c/d/e/f/.foorc.js'),
+    });
+  };
+
+  test('async', () => {
+    const readFileMock = mockReadFile(false, readFile);
+    return cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+    })
+      .search(startDir)
+      .then(result => {
+        checkResult(readFileMock, result);
+      });
+  });
+
+  test('sync', () => {
+    const readFileMock = mockReadFile(true, readFile);
+    const result = cosmiconfig('foo', {
+      rcExtensions: true,
+      stopDir: absolutePath('.'),
+      sync: true,
+    }).search(startDir);
+    checkResult(readFileMock, result);
   });
 });

--- a/test/successful-directories.test.js
+++ b/test/successful-directories.test.js
@@ -589,7 +589,6 @@ describe('finds JS file traversing from cwd', () => {
     process.cwd = originalCwd;
   });
 
-  const startDir = absolutePath('a/b/c/d/e/f');
   const readFile = searchPath => {
     switch (searchPath) {
       case absolutePath('a/b/c/d/e/f/package.json'):
@@ -627,7 +626,7 @@ describe('finds JS file traversing from cwd', () => {
     return cosmiconfig('foo', {
       stopDir: absolutePath('.'),
     })
-      .search(startDir)
+      .search()
       .then(result => {
         checkResult(readFileMock, result);
       });
@@ -639,7 +638,7 @@ describe('finds JS file traversing from cwd', () => {
     const result = cosmiconfig('foo', {
       stopDir: absolutePath('.'),
       sync: true,
-    }).search(startDir);
+    }).search();
     checkResult(readFileMock, result);
   });
 });

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -4,148 +4,186 @@ const util = require('./util');
 const cosmiconfig = require('../src');
 
 const absolutePath = util.absolutePath;
-const configFileLoader = util.configFileLoader;
-const testFuncsRunner = util.testFuncsRunner;
-const testSyncAndAsync = util.testSyncAndAsync;
 
-function makeFileTest(file, format) {
-  return sync => () => {
-    expect.hasAssertions();
-    return testFuncsRunner(sync, configFileLoader({ sync, format }, file), [
-      result => {
-        expect(result.config).toEqual({
-          foo: true,
-        });
-        expect(result.filepath).toBe(absolutePath(file));
-      },
-    ]);
+describe('loads defined JSON config path', () => {
+  const file = absolutePath('fixtures/foo.json');
+  const checkResult = result => {
+    expect(result.config).toEqual({ foo: true });
+    expect(result.filepath).toBe(file);
   };
-}
 
-describe('cosmiconfig', () => {
-  describe('load from file', () => {
-    describe('format not specified', () => {
-      testSyncAndAsync(
-        'loads defined JSON config path',
-        makeFileTest('fixtures/foo.json')
-      );
+  test('async', () => {
+    return cosmiconfig()
+      .load(file)
+      .then(checkResult);
+  });
 
-      testSyncAndAsync(
-        'loads defined YAML config path',
-        makeFileTest('fixtures/foo.yaml')
-      );
+  test('sync', () => {
+    const result = cosmiconfig(null, { sync: true }).load(file);
+    checkResult(result);
+  });
+});
 
-      testSyncAndAsync(
-        'loads defined JS config path',
-        makeFileTest('fixtures/foo.js')
-      );
+describe('loads defined YAML config path', () => {
+  const file = absolutePath('fixtures/foo.yaml');
+  const checkResult = result => {
+    expect(result.config).toEqual({ foo: true });
+    expect(result.filepath).toBe(file);
+  };
 
-      testSyncAndAsync(
-        'loads modularized JS config path',
-        makeFileTest('fixtures/foo-module.js')
-      );
+  test('async', () => {
+    return cosmiconfig()
+      .load(file)
+      .then(checkResult);
+  });
 
-      testSyncAndAsync(
-        'loads yaml-like JS config path',
-        makeFileTest('fixtures/foo-yaml-like.js')
-      );
+  test('sync', () => {
+    const result = cosmiconfig(null, { sync: true }).load(file);
+    checkResult(result);
+  });
+});
+
+describe('loads defined JS config path', () => {
+  const file = absolutePath('fixtures/foo.js');
+  const checkResult = result => {
+    expect(result.config).toEqual({ foo: true });
+    expect(result.filepath).toBe(file);
+  };
+
+  test('async', () => {
+    return cosmiconfig()
+      .load(file)
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfig(null, { sync: true }).load(file);
+    checkResult(result);
+  });
+});
+
+describe('loads modularized JS config path', () => {
+  const file = absolutePath('fixtures/foo-module.js');
+  const checkResult = result => {
+    expect(result.config).toEqual({ foo: true });
+    expect(result.filepath).toBe(file);
+  };
+
+  test('async', () => {
+    return cosmiconfig()
+      .load(file)
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfig(null, { sync: true }).load(file);
+    checkResult(result);
+  });
+});
+
+describe('loads yaml-like JS config path', () => {
+  const file = absolutePath('fixtures/foo-yaml-like.js');
+  const checkResult = result => {
+    expect(result.config).toEqual({ foo: true });
+    expect(result.filepath).toBe(file);
+  };
+
+  test('async', () => {
+    return cosmiconfig()
+      .load(file)
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfig(null, { sync: true }).load(file);
+    checkResult(result);
+  });
+});
+
+describe('respects options.configPath', () => {
+  const configPath = absolutePath('fixtures/foo.json');
+  const checkResult = result => {
+    expect(result.config).toEqual({
+      foo: true,
     });
+    expect(result.filepath).toBe(configPath);
+  };
 
-    describe('format specified', () => {
-      testSyncAndAsync(
-        'loads defined JSON config path',
-        makeFileTest('fixtures/foo.json', 'json')
-      );
+  test('async', () => {
+    return cosmiconfig('foo', { configPath })
+      .load()
+      .then(checkResult);
+  });
 
-      testSyncAndAsync(
-        'loads defined YAML config path',
-        makeFileTest('fixtures/foo.yaml', 'yaml')
-      );
+  test('sync', () => {
+    const result = cosmiconfig('foo', { configPath, sync: true }).load();
+    checkResult(result);
+  });
+});
 
-      testSyncAndAsync(
-        'loads defined JS config path',
-        makeFileTest('fixtures/foo.js', 'js')
-      );
-
-      testSyncAndAsync(
-        'loads modularized JS config path',
-        makeFileTest('fixtures/foo-module.js', 'js')
-      );
-
-      testSyncAndAsync(
-        'loads yaml-like JS config path',
-        makeFileTest('fixtures/foo-yaml-like.js', 'js')
-      );
+describe('loads package prop when configPath is package.json', () => {
+  const configPath = absolutePath('fixtures/package.json');
+  const checkResult = result => {
+    expect(result.config).toEqual({
+      bar: 'baz',
     });
+    expect(result.filepath).toBe(configPath);
+  };
 
-    testSyncAndAsync('respects options.configPath', sync => () => {
-      const configPath = absolutePath('fixtures/foo.json');
-      const explorer = cosmiconfig('foo', { configPath, sync });
-      return testFuncsRunner(sync, explorer.load(), [
-        result => {
-          expect(result.config).toEqual({
-            foo: true,
-          });
-          expect(result.filepath).toBe(configPath);
-        },
-      ]);
-    });
+  test('async', () => {
+    return cosmiconfig('foo', { configPath })
+      .load()
+      .then(checkResult);
+  });
 
-    testSyncAndAsync(
-      'loads package prop when configPath is package.json',
-      sync => () => {
-        const configPath = absolutePath('fixtures/package.json');
-        const explorer = cosmiconfig('foo', { configPath, sync });
-        return testFuncsRunner(sync, explorer.load(), [
-          result => {
-            expect(result.config).toEqual({
-              bar: 'baz',
-            });
-          },
-        ]);
-      }
+  test('sync', () => {
+    const result = cosmiconfig('foo', { configPath, sync: true }).load();
+    checkResult(result);
+  });
+});
+
+describe('runs transform', () => {
+  const configPath = absolutePath('fixtures/foo.json');
+  const transform = result => {
+    result.config.foo = [result.config.foo];
+    return result;
+  };
+  const checkResult = result => {
+    expect(result.config).toEqual({ foo: [true] });
+  };
+
+  test('async', () => {
+    return cosmiconfig(null, { transform })
+      .load(configPath)
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfig(null, { transform, sync: true }).load(
+      configPath
     );
+    checkResult(result);
+  });
+});
 
-    testSyncAndAsync('runs transform', sync => () => {
-      expect.hasAssertions();
-      return testFuncsRunner(
-        sync,
-        configFileLoader(
-          {
-            sync,
-            transform(result) {
-              result.config.foo = [result.config.foo];
-              return result;
-            },
-          },
-          'fixtures/foo.json'
-        ),
-        [
-          result => {
-            expect(result.config).toEqual({ foo: [true] });
-          },
-        ]
-      );
-    });
+describe('does not swallow transform errors', () => {
+  const configPath = absolutePath('fixtures/foo.json');
+  const transform = () => {
+    throw new Error('These pretzels are making me thirsty!');
+  };
 
-    it('does not swallow transform errors', () => {
-      const load = sync =>
-        configFileLoader(
-          {
-            sync,
-            transform() {
-              throw new Error('These pretzels are making me thirsty!');
-            },
-          },
-          'fixtures/foo.json'
-        );
-
-      expect.assertions(2);
-      expect(() => load(true)).toThrow('These pretzels are making me thirsty!');
-
-      return load(false).catch(err => {
-        expect(err.message).toBe('These pretzels are making me thirsty!');
+  test('async', () => {
+    expect.hasAssertions();
+    return cosmiconfig(null, { transform })
+      .load(configPath)
+      .catch(error => {
+        expect(error.message).toBe('These pretzels are making me thirsty!');
       });
-    });
+  });
+
+  test('sync', () => {
+    expect(() => {
+      cosmiconfig(null, { transform, sync: true }).load(configPath);
+    }).toThrow('These pretzels are making me thirsty!');
   });
 });

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -172,18 +172,23 @@ describe('does not swallow transform errors', () => {
     throw new Error('These pretzels are making me thirsty!');
   };
 
+  const checkError = error => {
+    expect(error.message).toBe('These pretzels are making me thirsty!');
+  };
+
   test('async', () => {
     expect.hasAssertions();
     return cosmiconfig(null, { transform })
       .load(configPath)
-      .catch(error => {
-        expect(error.message).toBe('These pretzels are making me thirsty!');
-      });
+      .catch(checkError);
   });
 
   test('sync', () => {
-    expect(() => {
+    expect.hasAssertions();
+    try {
       cosmiconfig(null, { transform, sync: true }).load(configPath);
-    }).toThrow('These pretzels are making me thirsty!');
+    } catch (error) {
+      checkError(error);
+    }
   });
 });

--- a/test/util.js
+++ b/test/util.js
@@ -3,36 +3,7 @@
 const fsMock = require('fs');
 const path = require('path');
 
-const cosmiconfig = require('../src');
-
-const absolutePath = (exports.absolutePath = str => path.join(__dirname, str));
-
-exports.configFileLoader = function configFileLoader(options, file) {
-  const load = cosmiconfig(null, options).load;
-  return load(absolutePath(file));
-};
-
-const chainFuncsSync = (result, func) => func(result);
-const chainFuncsAsync = (result, func) => result.then(func);
-
-exports.testFuncsRunner = (sync, init, funcs) =>
-  funcs.reduce(sync === true ? chainFuncsSync : chainFuncsAsync, init);
-
-/**
- * A utility function to run a given test in both sync and async.
- *
- * @param {string} name
- * @param {Function} testFn
- */
-exports.testSyncAndAsync = function testSyncAndAsync(name, testFn) {
-  describe('sync', () => {
-    it(name, testFn(true));
-  });
-
-  describe('async', () => {
-    it(name, testFn(false));
-  });
-};
+exports.absolutePath = str => path.join(__dirname, str);
 
 exports.mockStatIsDirectory = function mockStatIsDirectory(result) {
   const stats = {


### PR DESCRIPTION
Some of the structures in the current tests are coupled to the `sync` option. We'll need to revise that in preparation for separate async-sync functions ( https://github.com/davidtheclark/cosmiconfig/issues/112). Also, I'd like to experiment with some refactoring (with the goal of simplifying code). But I don't want to do either of those things without ensuring that we can change the source code without significantly changing the tests. So this PR will be to refactor the tests *in preparation for code changes* (separate sync functions instead of a sync option, and refactoring), but without changing the source code at all.

Then in a follow-up PR, we can change the source code and only slightly adjust the tests. A pattern like this, in the adjusted tests represented by this first commit:

```js
  test('async', () => {
    const readFileMock = mockReadFile(false, readFile);
    return cosmiconfig('foo', { stopDir: absolutePath('.') })
      .load(startDir)
      .then(result => {
        checkResult(readFileMock, result);
      });
  });

  test('sync', () => {
    const readFileMock = mockReadFile(true, readFile);
    const result = cosmiconfig('foo', {
      stopDir: absolutePath('.'),
      sync: true,
    }).load(startDir);
    checkResult(readFileMock, result);
  });
```

Could then be slightly tweaked to look like this, when we revise the function signatures:

```js
  const explorer = cosmiconfig('foo', { stopDir: absolutePath('.') });

  test('async', () => {
    const readFileMock = mockReadFile(false, readFile);
    return explorer
      .load(startDir)
      .then(result => {
        checkResult(readFileMock, result);
      });
  });

  test('sync', () => {
    const readFileMock = mockReadFile(true, readFile);
    const result = explorer.loadSync(startDir);
    checkResult(readFileMock, result);
  });
```

I started with just one test file. Feedback welcome. I'll then move on to the others.