### PR TITLE
Allow passing fs instance to createExplorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ If you want to throw an error, or if an empty configuration file means something
 
 ### fs
 
-Type:
+Type: Any object that's compatible with node's fs module. Specifically the following must be implemented:
 
 ```js
 interface ErrnoError extends Error {
@@ -464,6 +464,9 @@ interface FS {
   readFileSync(path: string, encoding: string): string;
 };
 ```
+
+Note that only a subset of the [fs API](https://nodejs.org/api/fs.html) is used.
+Also, use of flow is not required for using this config option.
 
 Default: `require('fs')`.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If you are still using v4, those v4 docs are available [in the `4.0.0` tag](http
   - [cache](#cache)
   - [transform](#transform)
   - [ignoreEmptySearchPlaces](#ignoreemptysearchplaces)
+  - [fs](#fs)
 - [Caching](#caching)
 - [Differences from rc](#differences-from-rc)
 - [Contributing & Development](#contributing--development)
@@ -438,6 +439,37 @@ If you'd like to load empty configuration files, instead, set this option to `fa
 
 Why might you want to load empty configuration files?
 If you want to throw an error, or if an empty configuration file means something to your program.
+
+### fs
+
+Type:
+
+```js
+interface ErrnoError extends Error {
+  code?: string;
+};
+
+interface Stats {
+  isDirectory(): boolean;
+};
+
+interface FS {
+  stat(path: string, callback?: (err: ?ErrnoError, stats: Stats) => any): void;
+  statSync(path: string): Stats;
+  readFile(
+    path: string,
+    encoding: string,
+    callback: (err: ?ErrnoError, data: string) => void
+  ): void;
+  readFileSync(path: string, encoding: string): string;
+};
+```
+
+Default: `require('fs')`.
+
+If for some reason, the file system is not available but you wish to leverage Cosmiconfig for it's search and parsing capabilities, you can do so by passing a virtual file system instance(ex: [`memory-fs`](https://github.com/webpack/memory-fs), [memfs](https://github.com/streamich/memfs)). See [#105](https://github.com/davidtheclark/cosmiconfig/issues/105) for more details.
+
+By default, Cosmiconfig uses the native [`fs`](https://nodejs.org/api/fs.html) module to search and load configuration files.
 
 ## Caching
 

--- a/flow-typed/defs.js
+++ b/flow-typed/defs.js
@@ -11,6 +11,7 @@ type LoaderResult = {
 
 // These are the user options with defaults applied.
 type ExplorerOptions = {
+  fs: FS,
   stopDir: string,
   cache: boolean,
   transform: CosmiconfigResult => CosmiconfigResult,
@@ -39,3 +40,24 @@ type LoaderEntry = {
 type Loaders = {
   [string]: LoaderEntry,
 };
+
+// interfaces for `fs` defined using https://github.com/facebook/flow/blob/master/lib/node.js
+
+interface ErrnoError extends Error {
+  code?: string;
+}
+
+interface Stats {
+  isDirectory(): boolean;
+}
+
+interface FS {
+  stat(path: string, callback?: (err: ?ErrnoError, stats: Stats) => any): void;
+  statSync(path: string): Stats;
+  readFile(
+    path: string,
+    encoding: string,
+    callback: (err: ?ErrnoError, data: string) => void
+  ): void;
+  readFileSync(path: string, encoding: string): string;
+}

--- a/flow-typed/modules.js
+++ b/flow-typed/modules.js
@@ -1,10 +1,3 @@
-declare module 'is-directory' {
-  declare module.exports: {
-    (filename: string, (err: ?Error, result: boolean) => void): void,
-    sync(filename: string): boolean,
-  };
-}
-
 declare module 'parse-json' {
   declare module.exports: (
     input: string,

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "jest": "^21.2.1",
     "lint-staged": "^6.0.0",
     "make-dir": "^1.2.0",
+    "memory-fs": "^0.4.1",
     "parent-module": "^0.1.0",
     "prettier": "^1.8.2",
     "remark-cli": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     ]
   },
   "dependencies": {
-    "is-directory": "^0.3.1",
     "js-yaml": "^3.9.0",
     "parse-json": "^4.0.0"
   },

--- a/src/getDirectory.js
+++ b/src/getDirectory.js
@@ -2,21 +2,19 @@
 'use strict';
 
 const path = require('path');
-const isDirectory = require('is-directory');
+const isDirectory = require('./isDirectory');
 
-function getDirectory(filepath: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    return isDirectory(filepath, (err, filepathIsDirectory) => {
-      if (err) {
-        return reject(err);
-      }
-      return resolve(filepathIsDirectory ? filepath : path.dirname(filepath));
-    });
-  });
+function getDirectory(fs: FS, filepath: string): Promise<string> {
+  return isDirectory(fs, filepath).then(
+    isDirResult => (isDirResult ? filepath : path.dirname(filepath))
+  );
 }
 
-getDirectory.sync = function getDirectorySync(filepath: string): string {
-  return isDirectory.sync(filepath) ? filepath : path.dirname(filepath);
+getDirectory.sync = function getDirectorySync(
+  fs: FS,
+  filepath: string
+): string {
+  return isDirectory.sync(fs, filepath) ? filepath : path.dirname(filepath);
 };
 
 module.exports = getDirectory;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 'use strict';
 
+const fs = require('fs');
 const os = require('os');
 const createExplorer = require('./createExplorer');
 const loaders = require('./loaders');
@@ -35,6 +36,7 @@ function cosmiconfig(
     stopDir: os.homedir(),
     cache: true,
     transform: identity,
+    fs,
   };
   const normalizedOptions: ExplorerOptions = Object.assign(
     {},

--- a/src/isDirectory.js
+++ b/src/isDirectory.js
@@ -1,0 +1,45 @@
+// @flow
+'use strict';
+
+function isDirectory(fs: FS, filepath: string): Promise<boolean> {
+  if (typeof filepath !== 'string') {
+    return Promise.reject(new TypeError('expected filepath to be a string'));
+  }
+
+  return new Promise((resolve, reject) => {
+    fs.stat(filepath, (err, stat) => {
+      if (err) {
+        // istanbul ignore else
+        if (err.code === 'ENOENT') {
+          return resolve(false);
+        }
+
+        // istanbul ignore next
+        return reject(err);
+      }
+
+      resolve(stat.isDirectory());
+    });
+  });
+}
+
+isDirectory.sync = function isDirectorySync(fs: FS, filepath: string): boolean {
+  if (typeof filepath !== 'string') {
+    throw new Error('expected filepath to be a string');
+  }
+
+  try {
+    const stat = fs.statSync(filepath);
+    return stat.isDirectory();
+  } catch (err) {
+    // istanbul ignore else
+    if (err.code === 'ENOENT') {
+      return false;
+    }
+
+    // istanbul ignore next
+    throw err;
+  }
+};
+
+module.exports = isDirectory;

--- a/src/isDirectory.js
+++ b/src/isDirectory.js
@@ -2,10 +2,6 @@
 'use strict';
 
 function isDirectory(fs: FS, filepath: string): Promise<boolean> {
-  if (typeof filepath !== 'string') {
-    return Promise.reject(new TypeError('expected filepath to be a string'));
-  }
-
   return new Promise((resolve, reject) => {
     fs.stat(filepath, (err, stat) => {
       if (err) {
@@ -24,10 +20,6 @@ function isDirectory(fs: FS, filepath: string): Promise<boolean> {
 }
 
 isDirectory.sync = function isDirectorySync(fs: FS, filepath: string): boolean {
-  if (typeof filepath !== 'string') {
-    throw new Error('expected filepath to be a string');
-  }
-
   try {
     const stat = fs.statSync(filepath);
     return stat.isDirectory();

--- a/src/readFile.js
+++ b/src/readFile.js
@@ -1,13 +1,15 @@
 // @flow
 'use strict';
 
-const fs = require('fs');
-
 type Options = {
   throwNotFound?: boolean,
 };
 
-function readFile(filepath: string, options?: Options): Promise<string | null> {
+function readFile(
+  fs: FS,
+  filepath: string,
+  options?: Options
+): Promise<string | null> {
   options = options || {};
   const throwNotFound = options.throwNotFound || false;
 
@@ -23,6 +25,7 @@ function readFile(filepath: string, options?: Options): Promise<string | null> {
 }
 
 readFile.sync = function readFileSync(
+  fs: FS,
   filepath: string,
   options?: Options
 ): string | null {

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -26,7 +26,7 @@ afterAll(() => {
 describe('cache is not used initially', () => {
   const searchPath = temp.absolutePath('a/b/c/d/e');
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
@@ -144,7 +144,7 @@ describe('cache is used when some directories in search are already visted', () 
   const firstSearchPath = temp.absolutePath('a/b/c/d/e');
   const secondSearchPath = temp.absolutePath('a/b/c/d/e/f');
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -232,7 +232,7 @@ describe('cache is not used when directly loading an unvisited file', () => {
 describe('cache is not used in a new cosmiconfig instance', () => {
   const searchPath = temp.absolutePath('a/b/c/d/e');
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
@@ -278,7 +278,7 @@ describe('cache is not used in a new cosmiconfig instance', () => {
 describe('clears file cache on calling clearLoadCache', () => {
   const loadPath = temp.absolutePath('a/b/c/d/.foorc');
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual(['a/b/c/d/.foorc']);
 
     expect(result).toEqual({
@@ -318,7 +318,7 @@ describe('clears file cache on calling clearLoadCache', () => {
 describe('clears file cache on calling clearCaches', () => {
   const loadPath = temp.absolutePath('a/b/c/d/.foorc');
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual(['a/b/c/d/.foorc']);
 
     expect(result).toEqual({
@@ -358,7 +358,7 @@ describe('clears file cache on calling clearCaches', () => {
 describe('clears directory cache on calling clearSearchCache', () => {
   const searchPath = temp.absolutePath('a/b/c/d/e');
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
@@ -408,7 +408,7 @@ describe('clears directory cache on calling clearSearchCache', () => {
 describe('clears directory cache on calling clearCaches', () => {
   const searchPath = temp.absolutePath('a/b/c/d/e');
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
@@ -474,7 +474,7 @@ describe('with cache disabled', () => {
 describe('with cache disabled, does not cache directory results', () => {
   const searchPath = temp.absolutePath('a/b/c/d/e');
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/package.json',
       'a/b/c/d/e/.foorc',
@@ -522,7 +522,7 @@ describe('with cache disabled, does not cache directory results', () => {
 describe('with cache disabled, does not cache file results', () => {
   const loadPath = temp.absolutePath('a/b/c/d/.foorc');
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual(['a/b/c/d/.foorc']);
 
     expect(result).toEqual({

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -25,10 +25,10 @@ describe('gives up if it cannot find the file', () => {
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
   const checkResult = (statSpy, readFileSpy, result) => {
-    const statPath = temp.getSpyPathCalls(statSpy);
+    const statPath = util.getSpyPathCalls(temp.dir, statSpy);
     expect(statPath).toEqual(['a/b']);
 
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/package.json',
       'a/b/.foorc',
@@ -79,7 +79,7 @@ describe('stops at stopDir and gives up', () => {
   const explorerOptions = { stopDir: temp.absolutePath('a') };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/package.json',
       'a/b/.foorc',

--- a/test/getDirectory.test.js
+++ b/test/getDirectory.test.js
@@ -40,16 +40,3 @@ test('returns a promise if sync is not true', () => {
   const res = getDirectory(fs, __dirname, false);
   expect(res).toBeInstanceOf(Promise);
 });
-
-test('propagates error thrown by is-directory in sync', () => {
-  expect(() => getDirectory.sync(fs, null, true)).toThrowError(
-    'expected filepath to be a string'
-  );
-});
-
-test('rejects with the error thrown by is-directory in async', () => {
-  expect.hasAssertions();
-  return getDirectory(fs, null, false).catch(err => {
-    expect(err.message).toBe('expected filepath to be a string');
-  });
-});

--- a/test/getDirectory.test.js
+++ b/test/getDirectory.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const getDirectory = require('../src/getDirectory');
 
 describe('returns the searchPath if it is a directory', () => {
@@ -9,11 +10,11 @@ describe('returns the searchPath if it is a directory', () => {
   };
 
   test('async', () => {
-    return getDirectory(subject, false).then(checkResult);
+    return getDirectory(fs, subject, false).then(checkResult);
   });
 
   test('sync', () => {
-    checkResult(getDirectory.sync(subject, true));
+    checkResult(getDirectory.sync(fs, subject, true));
   });
 });
 
@@ -24,11 +25,11 @@ describe('returns the parent directory if it is a file', () => {
   };
 
   test('async', () => {
-    return getDirectory(subject, false).then(checkResult);
+    return getDirectory(fs, subject, false).then(checkResult);
   });
 
   test('sync', () => {
-    checkResult(getDirectory.sync(subject, true));
+    checkResult(getDirectory.sync(fs, subject, true));
   });
 });
 
@@ -36,19 +37,19 @@ test('returns a promise if sync is not true', () => {
   // Although we explicitly pass `false`, the result will be a promise even
   // if a value was not passed, because it would be falsy and not exactly
   // equal to `true`.
-  const res = getDirectory(__dirname, false);
+  const res = getDirectory(fs, __dirname, false);
   expect(res).toBeInstanceOf(Promise);
 });
 
 test('propagates error thrown by is-directory in sync', () => {
-  expect(() => getDirectory.sync(null, true)).toThrowError(
+  expect(() => getDirectory.sync(fs, null, true)).toThrowError(
     'expected filepath to be a string'
   );
 });
 
 test('rejects with the error thrown by is-directory in async', () => {
   expect.hasAssertions();
-  return getDirectory(null, false).catch(err => {
+  return getDirectory(fs, null, false).catch(err => {
     expect(err.message).toBe('expected filepath to be a string');
   });
 });

--- a/test/isDirectory.test.js
+++ b/test/isDirectory.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const fs = require('fs');
+const isDirectory = require('../src/isDirectory');
+
+test('returns true if the filepath is a directory', () => {
+  expect.assertions(2);
+  expect(isDirectory.sync(fs, __dirname)).toBe(true);
+  return expect(isDirectory(fs, __dirname)).resolves.toBe(true);
+});
+
+test('returns false if the filepath is a file', () => {
+  expect.assertions(2);
+  expect(isDirectory.sync(fs, __filename)).toBe(false);
+  return expect(isDirectory(fs, __filename)).resolves.toBe(false);
+});
+
+test('returns false if the filepath does not exist', () => {
+  expect.assertions(2);
+  expect(isDirectory.sync(fs, 'missing.filepath')).toBe(false);
+  return expect(isDirectory(fs, 'missing.filepath')).resolves.toBe(false);
+});
+
+test('throws an error if the filepath is not a string', () => {
+  expect.assertions(2);
+  expect(() => isDirectory.sync(fs)).toThrow(
+    'expected filepath to be a string'
+  );
+  return isDirectory(fs).catch(err => {
+    expect(err.message).toBe('expected filepath to be a string');
+  });
+});

--- a/test/isDirectory.test.js
+++ b/test/isDirectory.test.js
@@ -20,13 +20,3 @@ test('returns false if the filepath does not exist', () => {
   expect(isDirectory.sync(fs, 'missing.filepath')).toBe(false);
   return expect(isDirectory(fs, 'missing.filepath')).resolves.toBe(false);
 });
-
-test('throws an error if the filepath is not a string', () => {
-  expect.assertions(2);
-  expect(() => isDirectory.sync(fs)).toThrow(
-    'expected filepath to be a string'
-  );
-  return isDirectory(fs).catch(err => {
-    expect(err.message).toBe('expected filepath to be a string');
-  });
-});

--- a/test/successful-directories.test.js
+++ b/test/successful-directories.test.js
@@ -30,7 +30,7 @@ describe('finds rc file in third searched dir, with a package.json lacking prop'
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -85,7 +85,7 @@ describe('finds package.json prop in second searched dir', () => {
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -131,7 +131,7 @@ describe('finds JS file in first searched dir', () => {
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
 
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
@@ -177,7 +177,7 @@ describe('finds .foorc.js file in first searched dir', () => {
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
 
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
@@ -223,7 +223,7 @@ describe('skips over empty file to find JS file in first searched dir', () => {
   const explorerOptions = { stopDir: temp.absolutePath('.') };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
 
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
@@ -270,7 +270,7 @@ describe('finds package.json in second dir searched, with alternate names', () =
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.wowza',
@@ -315,7 +315,7 @@ describe('finds rc file in third searched dir, skipping packageProp, parsing ext
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/.foorc',
       'a/b/c/d/e/f/foo.config.js',
@@ -360,7 +360,7 @@ describe('finds package.json file in second searched dir, skipping JS and RC fil
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/package.json',
@@ -399,7 +399,7 @@ describe('finds .foorc.json in second searched dir', () => {
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -446,7 +446,7 @@ describe('finds .foorc.yaml in first searched dir', () => {
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -487,7 +487,7 @@ describe('finds .foorc.yml in first searched dir', () => {
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -542,7 +542,7 @@ describe('adding myfooconfig.js to searchPlaces, finds it in first searched dir'
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -596,7 +596,7 @@ describe('finds JS file traversing from cwd', () => {
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc',
@@ -653,7 +653,7 @@ describe('searchPlaces can include subdirectories', () => {
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/.foorc.json',
       'a/b/c/d/e/f/package.json',
@@ -719,7 +719,7 @@ describe('custom loaders allow non-default file types', () => {
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc.json',
@@ -787,7 +787,7 @@ describe('adding custom loaders allows for default and non-default file types', 
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc.json',
@@ -844,7 +844,7 @@ describe('defaults loaders can be overridden', () => {
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual([
       'a/b/c/d/e/f/package.json',
       'a/b/c/d/e/f/.foorc.json',
@@ -904,7 +904,7 @@ describe('custom loaders can be async', () => {
   });
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual(['a/b/c/d/e/f/.foorc.things']);
 
     expect(result).toEqual({
@@ -956,7 +956,7 @@ describe('a custom loader entry can include just an async loader', () => {
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual(['a/b/c/d/e/f/.foorc.things']);
 
     expect(result).toEqual({
@@ -998,7 +998,7 @@ describe('a custom loader entry can include only a sync loader and work for both
   };
 
   const checkResult = (readFileSpy, result) => {
-    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    const filesChecked = util.getSpyPathCalls(temp.dir, readFileSpy);
     expect(filesChecked).toEqual(['a/b/c/d/e/f/.foorc.things']);
 
     expect(result).toEqual({

--- a/test/util.js
+++ b/test/util.js
@@ -7,6 +7,27 @@ const parentModule = require('parent-module');
 const os = require('os');
 const fs = require.requireActual('fs');
 
+// Extract and return file paths from the spy calls. The filepaths returned
+// are relative to the given directory. They are also normalized to be
+// consistent across platforms.
+function getSpyPathCalls(dir, spy) {
+  const calls = spy.mock.calls;
+
+  const result = calls.map(call => {
+    const filePath = call[0];
+    const relativePath = path.relative(dir, filePath);
+
+    /**
+     * Replace Windows backslash directory separators with forward slashes
+     * so expected paths will be consistent cross platform
+     */
+    const normalized = relativePath.replace(/\\/g, '/');
+    return normalized;
+  });
+
+  return result;
+}
+
 class TempDir {
   dir: string;
 
@@ -60,25 +81,6 @@ class TempDir {
     fs.writeFileSync(filePath, `${contents}\n`);
   }
 
-  getSpyPathCalls(spy) {
-    const calls = spy.mock.calls;
-
-    const result = calls.map(call => {
-      const filePath = call[0];
-      const relativePath = path.relative(this.dir, filePath);
-
-      /**
-       * Replace Windows backslash directory separators with forward slashes
-       * so expected paths will be consistent cross platform
-       */
-      const normalizeCrossPlatform = relativePath.replace(/\\/g, '/');
-
-      return normalizeCrossPlatform;
-    });
-
-    return result;
-  }
-
   clean() {
     const cleanPattern = this.absolutePath('**/*');
     const removed = del.sync(cleanPattern, {
@@ -98,4 +100,5 @@ class TempDir {
 
 module.exports = {
   TempDir,
+  getSpyPathCalls,
 };

--- a/test/virtual-fs.test.js
+++ b/test/virtual-fs.test.js
@@ -1,0 +1,224 @@
+'use strict';
+
+const path = require('path');
+const MemoryFileSystem = require('memory-fs');
+const cosmiconfig = require('../src');
+
+const fs = new MemoryFileSystem();
+
+const root = path.parse(process.cwd()).root;
+const absolutePath = (filename: string) => path.join(root, filename);
+
+function createDir(dir: string) {
+  fs.mkdirpSync(absolutePath(dir));
+}
+
+function createFile(filename: string, contents: string) {
+  const filePath = absolutePath(filename);
+  const fileDir = path.parse(filePath).dir;
+  fs.mkdirpSync(fileDir);
+  fs.writeFileSync(filePath, `${contents}\n`);
+}
+
+function getSpyPathCalls(spy) {
+  return spy.mock.calls.map(call => {
+    const filePath = call[0];
+    const relativePath = path.relative(root, filePath);
+    /**
+     * Replace Windows backslash directory separators with forward slashes
+     * so expected paths will be consistent cross platform
+     */
+    return relativePath.replace(/\\/g, '/');
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('with virtual file system', () => {
+  beforeEach(() => {
+    // reset virtual FS state
+    fs.data = {};
+  });
+
+  describe('loads defined JSON config path', () => {
+    beforeEach(() => {
+      createFile('foo.json', '{ "foo": true }');
+    });
+
+    const file = absolutePath('foo.json');
+    const explorer = cosmiconfig(undefined, { fs });
+    const checkResult = result => {
+      expect(result.config).toEqual({ foo: true });
+      expect(result.filepath).toBe(file);
+    };
+
+    test('async', () => {
+      expect.hasAssertions();
+      return explorer.load(file).then(checkResult);
+    });
+
+    test('sync', () => {
+      const result = explorer.loadSync(file);
+      checkResult(result);
+    });
+  });
+
+  describe('finds rc file in third searched dir, with a package.json lacking prop', () => {
+    beforeEach(() => {
+      createDir('a/b/c/d/e/f/');
+      createFile('a/b/c/d/package.json', '{ "false": "hope" }');
+      createFile('a/b/c/d/.foorc', '{ "found": true }');
+    });
+
+    const startDir = absolutePath('a/b/c/d/e/f');
+    const explorer = cosmiconfig('foo', { fs, stopDir: absolutePath('.') });
+
+    const checkResult = (readFileSpy, result) => {
+      const filesChecked = getSpyPathCalls(readFileSpy);
+      expect(filesChecked).toEqual([
+        'a/b/c/d/e/f/package.json',
+        'a/b/c/d/e/f/.foorc',
+        'a/b/c/d/e/f/.foorc.json',
+        'a/b/c/d/e/f/.foorc.yaml',
+        'a/b/c/d/e/f/.foorc.yml',
+        'a/b/c/d/e/f/.foorc.js',
+        'a/b/c/d/e/f/foo.config.js',
+        'a/b/c/d/e/package.json',
+        'a/b/c/d/e/.foorc',
+        'a/b/c/d/e/.foorc.json',
+        'a/b/c/d/e/.foorc.yaml',
+        'a/b/c/d/e/.foorc.yml',
+        'a/b/c/d/e/.foorc.js',
+        'a/b/c/d/e/foo.config.js',
+        'a/b/c/d/package.json',
+        'a/b/c/d/.foorc',
+      ]);
+
+      expect(result).toEqual({
+        config: { found: true },
+        filepath: absolutePath('a/b/c/d/.foorc'),
+      });
+    };
+
+    test('async', () => {
+      expect.hasAssertions();
+      const readFileSpy = jest.spyOn(fs, 'readFile');
+
+      return explorer.search(startDir).then(result => {
+        checkResult(readFileSpy, result);
+      });
+    });
+
+    test('sync', () => {
+      const readFileSpy = jest.spyOn(fs, 'readFileSync');
+      const result = explorer.searchSync(startDir);
+      checkResult(readFileSpy, result);
+    });
+  });
+
+  describe('throws error if defined file does not exist', () => {
+    const file = absolutePath('does/not/exist');
+    const explorer = cosmiconfig(undefined, { fs });
+    const checkError = error => {
+      expect(error.code).toBe('ENOENT');
+    };
+
+    test('async', () => {
+      expect.hasAssertions();
+      return explorer.load(file).catch(checkError);
+    });
+
+    test('sync', () => {
+      expect.hasAssertions();
+      try {
+        explorer.loadSync(file);
+      } catch (error) {
+        checkError(error);
+      }
+    });
+  });
+
+  describe('returns an empty config result for empty file, format JS', () => {
+    beforeEach(() => {
+      createFile('foo-empty.js', '');
+    });
+
+    const file = absolutePath('foo-empty.js');
+    const explorer = cosmiconfig(undefined, { fs });
+    const checkResult = result => {
+      expect(result).toEqual({
+        config: undefined,
+        filepath: file,
+        isEmpty: true,
+      });
+    };
+
+    test('async', () => {
+      expect.hasAssertions();
+      return explorer.load(file).then(checkResult);
+    });
+
+    test('sync', () => {
+      const result = explorer.loadSync(file);
+      checkResult(result);
+    });
+  });
+
+  describe('gives up if it cannot find the file', () => {
+    beforeEach(() => {
+      createDir('a/b/c/d/e/f/');
+    });
+
+    const startDir = absolutePath('a/b');
+    const explorer = cosmiconfig('foo', { fs, stopDir: absolutePath('.') });
+
+    const checkResult = (statSpy, readFileSpy, result) => {
+      const statPath = getSpyPathCalls(statSpy);
+      expect(statPath).toEqual(['a/b']);
+
+      const filesChecked = getSpyPathCalls(readFileSpy);
+      expect(filesChecked).toEqual([
+        'a/b/package.json',
+        'a/b/.foorc',
+        'a/b/.foorc.json',
+        'a/b/.foorc.yaml',
+        'a/b/.foorc.yml',
+        'a/b/.foorc.js',
+        'a/b/foo.config.js',
+        'a/package.json',
+        'a/.foorc',
+        'a/.foorc.json',
+        'a/.foorc.yaml',
+        'a/.foorc.yml',
+        'a/.foorc.js',
+        'a/foo.config.js',
+        'package.json',
+        '.foorc',
+        '.foorc.json',
+        '.foorc.yaml',
+        '.foorc.yml',
+        '.foorc.js',
+        'foo.config.js',
+      ]);
+
+      expect(result).toBe(null);
+    };
+
+    test('async', () => {
+      const readFileSpy = jest.spyOn(fs, 'readFile');
+      const statSpy = jest.spyOn(fs, 'stat');
+      return explorer.search(startDir).then(result => {
+        checkResult(statSpy, readFileSpy, result);
+      });
+    });
+
+    test('sync', () => {
+      const readFileSpy = jest.spyOn(fs, 'readFileSync');
+      const statSpy = jest.spyOn(fs, 'statSync');
+      const result = explorer.searchSync(startDir);
+      checkResult(statSpy, readFileSpy, result);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,7 +1017,7 @@ elegant-spinner@^1.0.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
 
-errno@~0.1.7:
+errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
@@ -2734,6 +2734,13 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memory-fs@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
+  dependencies:
+    errno "^0.1.3"
+    readable-stream "^2.0.1"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -3311,7 +3318,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:


### PR DESCRIPTION
- Defaults to `require('fs')`.
- fs instance needs to implement the following methods:
  - `stat`, `statSync`
  - `readFile`, `readFileSync`

Closes #105. 