### PR TITLE
fix: Support loading JS config from relative paths

### DIFF
--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -273,7 +273,7 @@ class Explorer {
       return cacheWrapper(this.loadCache, absoluteFilePath, () => {
         return readFile(absoluteFilePath, { throwNotFound: true })
           .then(content => {
-            return this.createCosmiconfigResult(filepath, content);
+            return this.createCosmiconfigResult(absoluteFilePath, content);
           })
           .then(this.config.transform);
       });
@@ -285,7 +285,10 @@ class Explorer {
     const absoluteFilePath = path.resolve(process.cwd(), filepath);
     return cacheWrapper(this.loadSyncCache, absoluteFilePath, () => {
       const content = readFile.sync(absoluteFilePath, { throwNotFound: true });
-      const result = this.createCosmiconfigResultSync(filepath, content);
+      const result = this.createCosmiconfigResultSync(
+        absoluteFilePath,
+        content
+      );
       return this.config.transform(result);
     });
   }

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -1,11 +1,12 @@
 // @flow
 'use strict';
 
+const path = require('path');
 const parseJson = require('parse-json');
 const yaml = require('js-yaml');
 
 function loadJs(filepath: string): Object {
-  const result = require(filepath);
+  const result = require(path.resolve(filepath));
   return result;
 }
 

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -1,12 +1,11 @@
 // @flow
 'use strict';
 
-const path = require('path');
 const parseJson = require('parse-json');
 const yaml = require('js-yaml');
 
 function loadJs(filepath: string): Object {
-  const result = require(path.resolve(filepath));
+  const result = require(filepath);
   return result;
 }
 

--- a/test/successful-directories.test.js
+++ b/test/successful-directories.test.js
@@ -1027,20 +1027,20 @@ describe('works fine if sync loader returns a Promise from a JS file', () => {
   const startDir = temp.absolutePath('a/b/c/d/e/f');
   beforeEach(() => {
     temp.createFile(
-      'a/b/c/d/e/f/foo.config.js',
+      'a/b/c/d/e/f/bar.config.js',
       'module.exports = Promise.resolve({ a: 1 });'
     );
   });
 
   const explorerOptions = {
     stopDir: temp.absolutePath('.'),
-    searchPlaces: ['foo.config.js'],
+    searchPlaces: ['bar.config.js'],
   };
 
   test('sync', () => {
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfig('bar', explorerOptions).searchSync(startDir);
     expect(result).toEqual({
-      filepath: temp.absolutePath('a/b/c/d/e/f/foo.config.js'),
+      filepath: temp.absolutePath('a/b/c/d/e/f/bar.config.js'),
       config: expect.any(Promise),
     });
     return result.config.then(resolved => {

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -389,3 +389,31 @@ describe('works fine if sync loader returns a Promise from a JS file', () => {
     });
   });
 });
+
+describe('loads defined JS config relative path', () => {
+  const currentDir = process.cwd();
+  beforeEach(() => {
+    temp.createFile('config/bar.js', 'module.exports = { bar: true };');
+    process.chdir(temp.dir);
+  });
+  afterEach(() => {
+    process.chdir(currentDir);
+  });
+
+  const file = './config/bar.js';
+  const checkResult = result => {
+    expect(result.config).toEqual({ bar: true });
+    expect(result.filepath).toBe(file);
+  };
+
+  test('async', () => {
+    return cosmiconfig()
+      .load(file)
+      .then(checkResult);
+  });
+
+  test('sync', () => {
+    const result = cosmiconfig().loadSync(file);
+    checkResult(result);
+  });
+});

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -400,20 +400,21 @@ describe('loads defined JS config relative path', () => {
     process.chdir(currentDir);
   });
 
-  const file = './config/bar.js';
+  const relativeFile = './config/bar.js';
+  const absoluteFile = temp.absolutePath(relativeFile);
   const checkResult = result => {
     expect(result.config).toEqual({ bar: true });
-    expect(result.filepath).toBe(file);
+    expect(result.filepath).toBe(absoluteFile);
   };
 
   test('async', () => {
     return cosmiconfig()
-      .load(file)
+      .load(relativeFile)
       .then(checkResult);
   });
 
   test('sync', () => {
-    const result = cosmiconfig().loadSync(file);
+    const result = cosmiconfig().loadSync(relativeFile);
     checkResult(result);
   });
 });


### PR DESCRIPTION
A tool based on [kcd-scripts](https://github.com/kentcdodds/kcd-scripts) that passes relative paths to `cosmiconfig().load()` (via `lint-staged --config ./node_modules/kcd-scripts/dist/config/lintstagedrc.js`) broke after lint-staged [upgraded to cosmiconfig 5](https://github.com/okonet/lint-staged/pull/444), and I believe I've narrowed it down to a missing `path.resolve()`.

There is a functioning workaround, `require.resolve()` the argument before passing it, but this is inconsistent with many other CLIs that accept `--config` parameters, such as [eslint](https://eslint.org/docs/user-guide/command-line-interface#-c---config), rollup (lol rollupjs.org is borked right now), and [prettier](https://prettier.io/docs/en/cli.html#find-config-path-and-config):
```
eslint --config ./dist/config/eslint.js
rollup --config ./dist/config/rollup.js
prettier --config ./dist/config/prettier.js
```

This pattern worked with cosmiconfig 4.
