### PR TITLE
fix: `no loader` error for unsupported extension

### DIFF
--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -184,7 +184,7 @@ class Explorer {
     }
 
     const loaderKey = path.extname(filepath) || 'noExt';
-    return this.config.loaders[loaderKey];
+    return this.config.loaders[loaderKey] || {};
   }
 
   getSyncLoaderForFile(filepath: string): SyncLoader {

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -314,3 +314,29 @@ describe('errors if only async loader is set but you call sync search', () => {
     }
   });
 });
+
+describe('errors if no loader is set but you call sync load', () => {
+  const file = temp.absolutePath('.foorc.things');
+  beforeEach(() => {
+    temp.createFile('.foorc.things', 'one\ntwo\nthree\t\t\n  four\n');
+  });
+
+  const explorerOptions = {
+    loaders: {},
+  };
+
+  const checkError = error => {
+    expect(error.message).toMatch(
+      /No sync loader specified for extension "\.things"/
+    );
+  };
+
+  test('sync', () => {
+    expect.hasAssertions();
+    try {
+      cosmiconfig('not_exist_rc_name', explorerOptions).loadSync(file);
+    } catch (error) {
+      checkError(error);
+    }
+  });
+});


### PR DESCRIPTION
Context: prettier/prettier#4962

Fixes `Cannot read property 'sync' of undefined` for unsupported extension.