### PR TITLE
clear matching require.cache entries

### DIFF
--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -33,19 +33,19 @@ class Explorer {
 
   clearLoadCache() {
     if (this.loadCache) {
-      this.loadCache.clear();
+      clearCache(this.loadCache);
     }
     if (this.loadSyncCache) {
-      this.loadSyncCache.clear();
+      clearCache(this.loadSyncCache);
     }
   }
 
   clearSearchCache() {
     if (this.searchCache) {
-      this.searchCache.clear();
+      clearCache(this.searchCache);
     }
     if (this.searchSyncCache) {
-      this.searchSyncCache.clear();
+      clearCache(this.searchSyncCache);
     }
   }
 
@@ -315,4 +315,27 @@ function nextDirUp(dir: string): string {
 function getExtensionDescription(filepath: string): string {
   const ext = path.extname(filepath);
   return ext ? `extension "${ext}"` : 'files without extensions';
+}
+
+function clearCache(cache: Map<string, any>) {
+  for (const filePath of cache.keys()) {
+    removeCachedModuleFromParent();
+    delete require.cache[filePath];
+  }
+
+  cache.clear();
+}
+
+// this prevents a memory leak
+// see https://github.com/sindresorhus/import-fresh/issues/2
+function removeCachedModuleFromParent(filePath) {
+  if (require.cache[filePath] && require.cache[filePath].parent) {
+    let i = require.cache[filePath].parent.children.length;
+
+    while (i--) {
+      if (require.cache[filePath].parent.children[i].id === filePath) {
+        require.cache[filePath].parent.children.splice(i, 1);
+      }
+    }
+  }
 }


### PR DESCRIPTION
@davidtheclark, @sudo-suhas

Jest supplies its own `require` which makes testing an issue.  I would prefer adding a test outside of jest for this case, especially since we lose out on code coverage ([jest doesn't implement `require.cache`](https://github.com/facebook/jest/issues/5120)).  If we want to stay within Jest, then I'll need to spend some time figuring out why [this block](https://github.com/olsonpm/cosmiconfig/blob/fix-require-cache/test/caches.test.js#L609-L612) fails.   `jest.resetModules` seems to be doing something asynchronous under the hood, but it will take me more time to understand what.

Please let me know what you think