### PR TITLE
Nested packageProp path

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,26 @@ Default: `` `${moduleName}` ``.
 
 Name of the property in `package.json` to look for.
 
+Use periods to access nested properties.
+
+Example:
+
+```js
+{
+  packageProp: 'engines.node'
+}
+```
+
+to access the value specified in the `package.json`
+
+```json
+{
+  "engines": {
+    "node": ">=4"
+  }
+}
+```
+
 ### stopDir
 
 Type: `string`.

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "import-fresh": "^2.0.0",
     "is-directory": "^0.3.1",
     "js-yaml": "^3.9.0",
+    "lodash.get": "^4.4.2",
     "parse-json": "^4.0.0"
   },
   "devDependencies": {

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const path = require('path');
+const get = require('lodash.get');
 const loaders = require('./loaders');
 const readFile = require('./readFile');
 const cacheWrapper = require('./cacheWrapper');
@@ -173,7 +174,7 @@ class Explorer {
 
   loadPackageProp(filepath: string, content: string) {
     const parsedContent = loaders.loadJson(filepath, content);
-    const packagePropValue = parsedContent[this.config.packageProp];
+    const packagePropValue = get(parsedContent, this.config.packageProp);
     return packagePropValue || null;
   }
 

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -140,22 +140,40 @@ describe('loads package prop when configPath is package.json', () => {
   });
 
   const configPath = temp.absolutePath('package.json');
-  const checkResult = result => {
-    expect(result.config).toEqual({
-      bar: 'baz',
-    });
+  const checkResult = (result, expectedConfig) => {
+    expect(result.config).toEqual(expectedConfig);
     expect(result.filepath).toBe(configPath);
   };
 
-  test('async', () => {
-    return cosmiconfig('foo')
-      .load(configPath)
-      .then(checkResult);
+  describe('simple package prop', () => {
+    const expectedConfig = { bar: 'baz' };
+
+    test('async', () => {
+      return cosmiconfig('foo')
+        .load(configPath)
+        .then(result => checkResult(result, expectedConfig));
+    });
+
+    test('sync', () => {
+      const result = cosmiconfig('foo').loadSync(configPath);
+      checkResult(result, expectedConfig);
+    });
   });
 
-  test('sync', () => {
-    const result = cosmiconfig('foo').loadSync(configPath);
-    checkResult(result);
+  describe('nested package prop', () => {
+    const explorer = cosmiconfig('foo', { packageProp: 'foo.bar' });
+    const expectedConfig = 'baz';
+
+    test('async', () => {
+      return explorer
+        .load(configPath)
+        .then(result => checkResult(result, expectedConfig));
+    });
+
+    test('sync', () => {
+      const result = explorer.loadSync(configPath);
+      checkResult(result, expectedConfig);
+    });
   });
 });
 

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -145,17 +145,18 @@ describe('loads package prop when configPath is package.json', () => {
     expect(result.filepath).toBe(configPath);
   };
 
-  describe('simple package prop', () => {
+  describe('default package prop', () => {
+    const explorer = cosmiconfig('foo');
     const expectedConfig = { bar: 'baz' };
 
     test('async', () => {
-      return cosmiconfig('foo')
+      return explorer
         .load(configPath)
         .then(result => checkResult(result, expectedConfig));
     });
 
     test('sync', () => {
-      const result = cosmiconfig('foo').loadSync(configPath);
+      const result = explorer.loadSync(configPath);
       checkResult(result, expectedConfig);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2647,6 +2647,11 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"


### PR DESCRIPTION
- Allows targeting of nested `package.json` values using dot notation

Closes #164