### PR TITLE
Implement packageFilenames: specify which files get the package.json special treatment

### DIFF
--- a/flow-typed/defs.js
+++ b/flow-typed/defs.js
@@ -21,7 +21,7 @@ type ExplorerOptions = {
   ignoreEmptySearchPlaces: boolean,
 };
 
-type ExplorerContext =   & {
+type ExplorerContext = ExplorerOptions & {
   loadCache: ?Map<string, Promise<CosmiconfigResult>>,
   loadSyncCache: ?Map<string, CosmiconfigResult>,
   searchCache: ?Map<string, Promise<CosmiconfigResult>>,

--- a/flow-typed/defs.js
+++ b/flow-typed/defs.js
@@ -14,13 +14,14 @@ type ExplorerOptions = {
   stopDir: string,
   cache: boolean,
   transform: CosmiconfigResult => CosmiconfigResult,
+  packageFilenames: Array<string>,
   packageProp: string,
   loaders: Loaders,
   searchPlaces: Array<string>,
   ignoreEmptySearchPlaces: boolean,
 };
 
-type ExplorerContext = ExplorerOptions & {
+type ExplorerContext =   & {
   loadCache: ?Map<string, Promise<CosmiconfigResult>>,
   loadSyncCache: ?Map<string, CosmiconfigResult>,
   searchCache: ?Map<string, Promise<CosmiconfigResult>>,

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -179,7 +179,7 @@ class Explorer {
   }
 
   getLoaderEntryForFile(filepath: string): LoaderEntry {
-    if (this.config.packageFilenames.includes(path.basename(filepath))) {
+    if (this.config.packageFilenames.indexOf(path.basename(filepath)) >= 0) {
       const loader = this.loadPackageProp.bind(this);
       return { sync: loader, async: loader };
     }

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -179,7 +179,7 @@ class Explorer {
   }
 
   getLoaderEntryForFile(filepath: string): LoaderEntry {
-    if (path.basename(filepath) === 'package.json') {
+    if (this.config.packageFilenames.includes(path.basename(filepath))) {
       const loader = this.loadPackageProp.bind(this);
       return { sync: loader, async: loader };
     }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ module.exports = cosmiconfig;
 function cosmiconfig(
   moduleName: string,
   options: {
+    packageFilenames?: Array<string>,
     packageProp?: string,
     loaders?: Object,
     searchPlaces?: Array<string>,
@@ -21,6 +22,7 @@ function cosmiconfig(
 ) {
   options = options || {};
   const defaults = {
+    packageFilenames: ['package.json'],
     packageProp: moduleName,
     searchPlaces: [
       'package.json',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,6 +35,7 @@ describe('cosmiconfig', () => {
     expect(createExplorerMock).toHaveBeenCalledTimes(1);
     const explorerOptions = createExplorerMock.mock.calls[0][0];
     expect(explorerOptions).toMatchObject({
+      packageFilenames: ['package.json'],
       packageProp: moduleName,
       searchPlaces: [
         'package.json',
@@ -79,6 +80,7 @@ describe('cosmiconfig', () => {
       stopDir: __dirname,
       cache: false,
       searchPlaces: ['.foorc.json', 'wildandfree.js'],
+      packageFilenames: ['manifest.json'],
       packageProp: 'wildandfree',
       ignoreEmptySearchPlaces: false,
       loaders: {
@@ -91,6 +93,7 @@ describe('cosmiconfig', () => {
 
     const explorerOptions = createExplorerMock.mock.calls[0][0];
     expect(explorerOptions).toMatchObject({
+      packageFilenames: ['manifest.json'],
       packageProp: 'wildandfree',
       searchPlaces: ['.foorc.json', 'wildandfree.js'],
       ignoreEmptySearchPlaces: false,


### PR DESCRIPTION
Implements #172.

Adds a new option `packageFilenames: null | string | Array<string>;`  Defaults to `['package.json']`.  Controls which config files will be given special treatment as a `package.json` file.

If you want to pull config from a `packageProp` of an alternative file, say `manifest.json`, you can do that.
You can also disable special-casing entirely, so that `package.json` can be loaded through the same code paths as any other config file.