### PR TITLE
Migrate to the lodash package

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "import-fresh": "^2.0.0",
     "is-directory": "^0.3.1",
     "js-yaml": "^3.9.0",
-    "lodash.get": "^4.4.2",
+    "lodash": "^4.17.11",
     "parse-json": "^4.0.0"
   },
   "devDependencies": {

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const path = require('path');
-const get = require('lodash.get');
+const get = require('lodash/get');
 const loaders = require('./loaders');
 const readFile = require('./readFile');
 const cacheWrapper = require('./cacheWrapper');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2647,14 +2647,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
The modularized lodash packages are unmaintained since 2 years, lagging a lot behind the main lodash package. Partial imports of lodash are the preferred way.
See https://github.com/lodash/lodash/issues/2969