### PR TITLE
FIX: NODE-SECURITY-813: js-yaml < 3.13.1 code injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "import-fresh": "^2.0.0",
     "is-directory": "^0.3.1",
-    "js-yaml": "^3.13.0",
+    "js-yaml": "^3.13.1",
     "parse-json": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Addresses the following [CVE](https://www.npmjs.com/advisories/813).

Edit: Closes #183