### PR TITLE
Fail CI if package.json and yarn lock are out of sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ matrix:
     - node_js: "8"
       after_success: "bash <(curl -s https://codecov.io/bash)"
     - node_js: "10"
+install:
+  - yarn install --frozen-lockfile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ cache:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - yarn install
+  - yarn install --frozen-lockfile
 
 test_script:
   - node --version


### PR DESCRIPTION
This would prevent builds for PRs that only update the `package.json` to succeed.