### PR TITLE
Protect against undefined path in new getPropertyByPath

### DIFF
--- a/src/getPropertyByPath.js
+++ b/src/getPropertyByPath.js
@@ -6,10 +6,17 @@
 // object are used directly (even if they include a period).
 // Nested property names that include periods, within a path, are only
 // understood in array paths.
-function getPropertyByPath(source: Object, path: string | Array<string>): any {
+function getPropertyByPath(
+  source: Object,
+  path: ?(string | Array<string>)
+): any {
+  if (path === undefined || path === null) return undefined;
+
   if (typeof path === 'string' && source.hasOwnProperty(path)) {
     return source[path];
   }
+
+  if (path.length === 0) return undefined;
 
   const parsedPath = typeof path === 'string' ? path.split('.') : path;
   return parsedPath.reduce((previous, key) => {

--- a/test/getPropertyByPath.test.js
+++ b/test/getPropertyByPath.test.js
@@ -37,6 +37,12 @@ describe('with period-delimited string path', () => {
   });
 
   test('returns undefined', () => {
+    expect(getPropertyPath(source, undefined)).toBeUndefined();
+
+    expect(getPropertyPath(source, null)).toBeUndefined();
+
+    expect(getPropertyPath(source, [])).toBeUndefined();
+
     expect(getPropertyPath(source, 'beetle')).toBeUndefined();
 
     expect(getPropertyPath(source, 'ant.beetle.cootie.fleeee')).toBeUndefined();


### PR DESCRIPTION
This PR fixes #188.

In version 5.2.0 (#177 specifically), the Lodash `_.get` method was replaced by a local function. This local function differed in that `_.get(obj, undefined)` would return `undefined`, but this function would just crash (trying to access `undefined.reduce`).

This protects against that possibility. Also added tests.