### PR TITLE
Remove support for Node 4

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "no-var": "off",
     "prefer-const": "off",
     "prefer-arrow-callback": "off",
-    "node/no-unsupported-features": ["error", {"version": 4}],
+    "node/no-unsupported-features": ["error", {"version": 6}],
     "func-names": ["error", "always"],
     "prefer-template": "error",
     "object-shorthand": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "no-var": "off",
     "prefer-const": "off",
     "prefer-arrow-callback": "off",
-    "node/no-unsupported-features": ["error", {"version": 6}],
+    "node/no-unsupported-features": ["error", {"version": 8}],
     "func-names": ["error", "always"],
     "prefer-template": "error",
     "object-shorthand": [

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ branches:
     - master
 matrix:
   include:
-    - node_js: "6"
     - node_js: "8"
-      after_success: "bash <(curl -s https://codecov.io/bash)"
     - node_js: "10"
+      after_success: "bash <(curl -s https://codecov.io/bash)"
     - node_js: "12"
 install:
   - yarn install --frozen-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ branches:
     - master
 matrix:
   include:
-    - node_js: "4"
     - node_js: "6"
     - node_js: "8"
       after_success: "bash <(curl -s https://codecov.io/bash)"
     - node_js: "10"
+    - node_js: "12"
 install:
   - yarn install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD
 
-- **Breaking change:** Remove support for Node 4.
+- **Breaking change:** Remove support for Node 4 and 6. Requires Node 8+.
 
 ## 5.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- **Breaking change:** Remove support for Node 4.
+
 ## 5.2.1
 
 - Chore: Upgrade `js-yaml` to avoid npm audit warning.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you are still using v4, those v4 docs are available [in the `4.0.0` tag](http
 npm install cosmiconfig
 ```
 
-Tested in Node 6+.
+Tested in Node 8+.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you are still using v4, those v4 docs are available [in the `4.0.0` tag](http
 npm install cosmiconfig
 ```
 
-Tested in Node 4+.
+Tested in Node 6+.
 
 ## Usage
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,9 @@ environment:
   - nodejs_version: 10
   - nodejs_version: 12
 
-platform:
-  - x86
-  - x64
-
-
 install:
   # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) x64
   - yarn install --frozen-lockfile
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,10 @@
 
 environment:
   matrix:
-    - nodejs_version: 4
     - nodejs_version: 6
     - nodejs_version: 8
     - nodejs_version: 10
+    - nodejs_version: 12
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,5 @@
 # http://www.appveyor.com/docs/appveyor-yml
 
-environment:
-  matrix:
-    - nodejs_version: 6
-    - nodejs_version: 8
-    - nodejs_version: 10
-    - nodejs_version: 12
-
 branches:
   only:
     - master
@@ -19,8 +12,21 @@ deploy: off
 cache:
  - "%LOCALAPPDATA%\\Yarn"
 
+environment:
+  matrix:
+  - nodejs_version: 6
+  - nodejs_version: 8
+  - nodejs_version: 10
+  - nodejs_version: 12
+
+platform:
+  - x86
+  - x64
+
+
 install:
-  - ps: Install-Product node $env:nodejs_version x64
+  # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - yarn install --frozen-lockfile
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ cache:
 
 environment:
   matrix:
-  - nodejs_version: 6
   - nodejs_version: 8
   - nodejs_version: 10
   - nodejs_version: 12

--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
     "remark-preset-davidtheclark": "^0.7.0"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
     "remark-preset-davidtheclark": "^0.7.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   }
 }


### PR DESCRIPTION
This PR removes support for Node 4 and runs tests in Node 12 on CI.

Here are some reasons I think we may as well remove Node 4 support:

- Smooth the way going forward. If we want to be able to upgrade or shift dependencies, we are held back by Node 4 — for example, @olsonpm's [look into alternative YAML parsers](https://github.com/davidtheclark/cosmiconfig/issues/183#issuecomment-485171989).
- This library has been very stable, so any consumer that still wants to support Node 4 *can*, with versions that have already been published.
- We should publish some type checking of arguments (see https://github.com/davidtheclark/cosmiconfig/issues/188); and although I think we could do that with a patch release, it's a little nicer to do it with a major release. That opens the gate for removing support for Node 4.

@olsonpm and @sudo-suhas for review, please.

We can follow up with any changes that you think are worthwhile and unblocked by dropping Node 4 support.
