### PR TITLE
Node 8 updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "no-var": "off",
     "prefer-const": "off",
     "prefer-arrow-callback": "off",
-    "node/no-unsupported-features": ["error", {"version": 8}],
+    "node/no-unsupported-features": ["error", {"version": "8.9"}], // first LTS 8 release
     "func-names": ["error", "always"],
     "prefer-template": "error",
     "object-shorthand": [

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/davidtheclark/cosmiconfig#readme",
   "prettier": {
-    "trailingComma": "es5",
+    "trailingComma": "all",
     "singleQuote": true,
     "printWidth": 80,
     "tabWidth": 2

--- a/src/createExplorer.js
+++ b/src/createExplorer.js
@@ -64,8 +64,8 @@ class Explorer {
       if (!loader) {
         throw new Error(
           `No loader specified for ${getExtensionDescription(
-            place
-          )}, so searchPlaces item "${place}" is invalid`
+            place,
+          )}, so searchPlaces item "${place}" is invalid`,
         );
       }
     });
@@ -160,7 +160,7 @@ class Explorer {
 
   nextDirectoryToSearch(
     currentDir: string,
-    currentResult: CosmiconfigResult
+    currentResult: CosmiconfigResult,
   ): ?string {
     if (this.shouldSearchStopWithResult(currentResult)) {
       return null;
@@ -176,7 +176,7 @@ class Explorer {
     const parsedContent = loaders.loadJson(filepath, content);
     const packagePropValue = getPropertyByPath(
       parsedContent,
-      this.config.packageProp
+      this.config.packageProp,
     );
     return packagePropValue || null;
   }
@@ -195,7 +195,7 @@ class Explorer {
     const entry = this.getLoaderEntryForFile(filepath);
     if (!entry.sync) {
       throw new Error(
-        `No sync loader specified for ${getExtensionDescription(filepath)}`
+        `No sync loader specified for ${getExtensionDescription(filepath)}`,
       );
     }
     return entry.sync;
@@ -206,7 +206,7 @@ class Explorer {
     const loader = entry.async || entry.sync;
     if (!loader) {
       throw new Error(
-        `No async loader specified for ${getExtensionDescription(filepath)}`
+        `No async loader specified for ${getExtensionDescription(filepath)}`,
       );
     }
     return loader;
@@ -215,7 +215,7 @@ class Explorer {
   loadFileContent(
     mode: 'sync' | 'async',
     filepath: string,
-    content: string | null
+    content: string | null,
   ): Promise<LoadedFileContent> | LoadedFileContent {
     if (content === null) {
       return null;
@@ -232,7 +232,7 @@ class Explorer {
 
   loadedContentToCosmiconfigResult(
     filepath: string,
-    loadedContent: LoadedFileContent
+    loadedContent: LoadedFileContent,
   ): CosmiconfigResult {
     if (loadedContent === null) {
       return null;
@@ -245,7 +245,7 @@ class Explorer {
 
   createCosmiconfigResult(
     filepath: string,
-    content: string | null
+    content: string | null,
   ): Promise<CosmiconfigResult> {
     return Promise.resolve()
       .then(() => {
@@ -258,7 +258,7 @@ class Explorer {
 
   createCosmiconfigResultSync(
     filepath: string,
-    content: string | null
+    content: string | null,
   ): CosmiconfigResult {
     const loaderResult = this.loadFileContent('sync', filepath, content);
     return this.loadedContentToCosmiconfigResult(filepath, loaderResult);
@@ -291,7 +291,7 @@ class Explorer {
       const content = readFile.sync(absoluteFilePath, { throwNotFound: true });
       const result = this.createCosmiconfigResultSync(
         absoluteFilePath,
-        content
+        content,
       );
       return this.config.transform(result);
     });

--- a/src/getPropertyByPath.js
+++ b/src/getPropertyByPath.js
@@ -8,7 +8,7 @@
 // understood in array paths.
 function getPropertyByPath(
   source: { [key: string]: any },
-  path: string | Array<string>
+  path: string | Array<string>,
 ): any {
   if (typeof path === 'string' && source.hasOwnProperty(path)) {
     return source[path];

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ function cosmiconfig(
     stopDir?: string,
     cache?: boolean,
     transform?: CosmiconfigResult => CosmiconfigResult,
-  }
+  },
 ) {
   options = options || {};
   const defaults = {
@@ -42,7 +42,7 @@ function cosmiconfig(
     options,
     {
       loaders: normalizeLoaders(options.loaders),
-    }
+    },
   );
 
   return createExplorer(normalizedOptions);

--- a/src/readFile.js
+++ b/src/readFile.js
@@ -24,7 +24,7 @@ function readFile(filepath: string, options?: Options): Promise<string | null> {
 
 readFile.sync = function readFileSync(
   filepath: string,
-  options?: Options
+  options?: Options,
 ): string | null {
   options = options || {};
   const throwNotFound = options.throwNotFound || false;

--- a/test/failed-directories.test.js
+++ b/test/failed-directories.test.js
@@ -212,7 +212,7 @@ describe('throws error for invalid JS in .config.js file', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/foo.config.js',
-      'module.exports = { found: true: false,'
+      'module.exports = { found: true: false,',
     );
   });
 
@@ -560,7 +560,7 @@ describe('throws error if a file in searchPlaces does not have a corresponding l
 
   const checkError = error => {
     expect(error.message).toMatch(
-      /No loader specified for extension "\.things"/
+      /No loader specified for extension "\.things"/,
     );
   };
 
@@ -589,7 +589,7 @@ describe('throws error if an extensionless file in searchPlaces does not have a 
 
   const checkError = error => {
     expect(error.message).toMatch(
-      /No loader specified for files without extensions/
+      /No loader specified for files without extensions/,
     );
   };
 
@@ -648,7 +648,7 @@ describe('errors not swallowed when async custom loader throws them', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/.foorc.things',
-      'one\ntwo\nthree\t\t\n  four\n'
+      'one\ntwo\nthree\t\t\n  four\n',
     );
   });
 
@@ -683,7 +683,7 @@ describe('errors not swallowed when async custom loader rejects', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/.foorc.things',
-      'one\ntwo\nthree\t\t\n  four\n'
+      'one\ntwo\nthree\t\t\n  four\n',
     );
   });
 
@@ -718,7 +718,7 @@ describe('errors if only async loader is set but you call sync search', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/.foorc.things',
-      'one\ntwo\nthree\t\t\n  four\n'
+      'one\ntwo\nthree\t\t\n  four\n',
     );
   });
 
@@ -736,7 +736,7 @@ describe('errors if only async loader is set but you call sync search', () => {
 
   const checkError = error => {
     expect(error.message).toMatch(
-      /No sync loader specified for extension "\.things"/
+      /No sync loader specified for extension "\.things"/,
     );
   };
 
@@ -756,7 +756,7 @@ describe('errors if it cannot figure out an async loader', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/.foorc.things',
-      'one\ntwo\nthree\t\t\n  four\n'
+      'one\ntwo\nthree\t\t\n  four\n',
     );
   });
 
@@ -774,7 +774,7 @@ describe('errors if it cannot figure out an async loader', () => {
 
   const checkError = error => {
     expect(error.message).toMatch(
-      /No async loader specified for extension "\.things"/
+      /No async loader specified for extension "\.things"/,
     );
   };
 

--- a/test/failed-files.test.js
+++ b/test/failed-files.test.js
@@ -301,7 +301,7 @@ describe('errors if only async loader is set but you call sync search', () => {
 
   const checkError = error => {
     expect(error.message).toMatch(
-      /No sync loader specified for extension "\.things"/
+      /No sync loader specified for extension "\.things"/,
     );
   };
 
@@ -327,7 +327,7 @@ describe('errors if no loader is set but you call sync load', () => {
 
   const checkError = error => {
     expect(error.message).toMatch(
-      /No sync loader specified for extension "\.things"/
+      /No sync loader specified for extension "\.things"/,
     );
   };
 

--- a/test/getDirectory.test.js
+++ b/test/getDirectory.test.js
@@ -42,7 +42,7 @@ test('returns a promise if sync is not true', () => {
 
 test('propagates error thrown by is-directory in sync', () => {
   expect(() => getDirectory.sync(null, true)).toThrowError(
-    'expected filepath to be a string'
+    'expected filepath to be a string',
   );
 });
 

--- a/test/getPropertyByPath.test.js
+++ b/test/getPropertyByPath.test.js
@@ -32,7 +32,7 @@ describe('with period-delimited string path', () => {
     expect(getPropertyPath(source, 'ant.beetle.cootie.flea')).toBe('foo');
 
     expect(getPropertyPath(source, 'ant.beetle.louse')).toBe(
-      source.ant.beetle.louse
+      source.ant.beetle.louse,
     );
   });
 
@@ -52,11 +52,11 @@ describe('with array path', () => {
     expect(getPropertyPath(source, ['ant'])).toBe(source.ant);
 
     expect(getPropertyPath(source, ['ant', 'beetle', 'cootie', 'flea'])).toBe(
-      'foo'
+      'foo',
     );
 
     expect(getPropertyPath(source, ['ant', 'beetle', 'louse'])).toBe(
-      source.ant.beetle.louse
+      source.ant.beetle.louse,
     );
   });
 
@@ -64,17 +64,17 @@ describe('with array path', () => {
     expect(getPropertyPath(source, ['beetle'])).toBeUndefined();
 
     expect(
-      getPropertyPath(source, ['ant', 'beetle', 'cootie', 'fleeee'])
+      getPropertyPath(source, ['ant', 'beetle', 'cootie', 'fleeee']),
     ).toBeUndefined();
 
     expect(
-      getPropertyPath(source, ['ant', 'beetle', 'vermin'])
+      getPropertyPath(source, ['ant', 'beetle', 'vermin']),
     ).toBeUndefined();
   });
 
   test('handles property names with periods', () => {
     expect(
-      getPropertyPath(source, ['ant', 'fancy.name', 'another.fancy.name'])
+      getPropertyPath(source, ['ant', 'fancy.name', 'another.fancy.name']),
     ).toBe(9);
 
     expect(
@@ -83,7 +83,7 @@ describe('with array path', () => {
         'fancy.name',
         'another.fancy.name',
         'foo',
-      ])
+      ]),
     ).toBeUndefined();
 
     expect(getPropertyPath(source, ['ant', 'fancy.namez'])).toBeUndefined();

--- a/test/successful-directories.test.js
+++ b/test/successful-directories.test.js
@@ -77,7 +77,7 @@ describe('finds package.json prop in second searched dir', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/package.json',
-      '{ "author": "Todd", "foo": { "found": true } }'
+      '{ "author": "Todd", "foo": { "found": true } }',
     );
   });
 
@@ -124,11 +124,11 @@ describe('finds package.json with nested packageProp in second searched dir', ()
     // First package.json exists but does not include the nested packageProp.
     temp.createFile(
       'a/b/c/d/e/f/package.json',
-      '{ "author": "Todd", "configs": { "notYourPkg": { "yes": "ofcourse" } } }'
+      '{ "author": "Todd", "configs": { "notYourPkg": { "yes": "ofcourse" } } }',
     );
     temp.createFile(
       'a/b/c/d/e/package.json',
-      '{ "author": "Todd", "configs": { "pkg": { "please": "no" } } }'
+      '{ "author": "Todd", "configs": { "pkg": { "please": "no" } } }',
     );
   });
 
@@ -177,7 +177,7 @@ describe('finds JS file in first searched dir', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/foo.config.js',
-      'module.exports = { found: true };'
+      'module.exports = { found: true };',
     );
   });
 
@@ -223,7 +223,7 @@ describe('finds .foorc.js file in first searched dir', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/.foorc.js',
-      'module.exports = { found: true };'
+      'module.exports = { found: true };',
     );
   });
 
@@ -268,7 +268,7 @@ describe('skips over empty file to find JS file in first searched dir', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/foo.config.js',
-      'module.exports = { found: true };'
+      'module.exports = { found: true };',
     );
     temp.createFile('a/b/c/d/e/f/.foorc', '');
   });
@@ -404,7 +404,7 @@ describe('finds package.json file in second searched dir, skipping JS and RC fil
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/package.json',
-      '{ "author": "Todd", "foo": { "found": true } }'
+      '{ "author": "Todd", "foo": { "found": true } }',
     );
   });
 
@@ -576,7 +576,7 @@ describe('adding myfooconfig.js to searchPlaces, finds it in first searched dir'
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/myfooconfig.js',
-      'module.exports = { found: true };'
+      'module.exports = { found: true };',
     );
   });
 
@@ -635,7 +635,7 @@ describe('finds JS file traversing from cwd', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/foo.config.js',
-      'module.exports = { found: true };'
+      'module.exports = { found: true };',
     );
 
     process.chdir(temp.absolutePath('a/b/c/d/e/f'));
@@ -940,7 +940,7 @@ describe('custom loaders can be async', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/.foorc.things',
-      'one\ntwo\nthree\t\t\n  four\n'
+      'one\ntwo\nthree\t\t\n  four\n',
     );
     loadThingsSync = jest.fn(() => {
       return { things: true };
@@ -993,7 +993,7 @@ describe('a custom loader entry can include just an async loader', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/.foorc.things',
-      'one\ntwo\nthree\t\t\n  four\n'
+      'one\ntwo\nthree\t\t\n  four\n',
     );
   });
 
@@ -1035,7 +1035,7 @@ describe('a custom loader entry can include only a sync loader and work for both
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/.foorc.things',
-      'one\ntwo\nthree\t\t\n  four\n'
+      'one\ntwo\nthree\t\t\n  four\n',
     );
   });
 
@@ -1082,7 +1082,7 @@ describe('works fine if sync loader returns a Promise from a JS file', () => {
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/bar.config.js',
-      'module.exports = Promise.resolve({ a: 1 });'
+      'module.exports = Promise.resolve({ a: 1 });',
     );
   });
 

--- a/test/successful-files.test.js
+++ b/test/successful-files.test.js
@@ -145,7 +145,7 @@ describe('loads package prop when configPath is package.json', () => {
       "otherPackage": {
         "please": "no"
       }
-    }`
+    }`,
     );
   });
 
@@ -443,7 +443,7 @@ describe('works fine if sync loader returns a Promise from a JS file', () => {
   beforeEach(() => {
     temp.createFile(
       'foo.config.js',
-      'module.exports = Promise.resolve({ a: 1 });'
+      'module.exports = Promise.resolve({ a: 1 });',
     );
   });
 


### PR DESCRIPTION
With node 8 you can enable trailing commas for everything. Also, eslint should target node 8.9 because that is the first LTS release and no additional features were added after, such as object spread.