### PR TITLE
Breaking: remove cosmiconfig.loaders and add named export defaultLoaders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Migrate from Flowtype to Typescript
 - **Breaking change:** Remove support for Node 4 and 6. Requires Node 8+.
+- **Breaking change:** Remove `cosmiconfig.loaders` and add named export `defaultLoaders`.
 - **Breaking change:** Use named export `cosmiconfig`. (see example below)
 
 ```js

--- a/README.md
+++ b/README.md
@@ -303,17 +303,19 @@ Default: See below.
 
 An object that maps extensions to the loader functions responsible for loading and parsing files with those extensions.
 
-Cosmiconfig exposes its default loaders for `.js`, `.json`, and `.yaml` as `cosmiconfig.loadJs`, `cosmiconfig.loadJson`, and `cosmiconfig.loadYaml`, respectively.
+Cosmiconfig exposes its default loaders as a named export `defaultLoaders` for `.js`, `.json`, and `.yaml` as `defaultLoaders.loadJs`, `defaultLoaders.loadJson`, and `defaultLoaders.loadYaml`, respectively.
 
 **Default `loaders`:**
 
 ```js
+const { defaultLoaders } = require('cosmiconfig');
+
 {
-  '.json': cosmiconfig.loadJson,
-  '.yaml': cosmiconfig.loadYaml,
-  '.yml': cosmiconfig.loadYaml,
-  '.js': cosmiconfig.loadJs,
-  noExt: cosmiconfig.loadYaml
+  '.json': defaultLoaders.loadJson,
+  '.yaml': defaultLoaders.loadYaml,
+  '.yml': defaultLoaders.loadYaml,
+  '.js': defaultLoaders.loadJs,
+  noExt: defaultLoaders.loadYaml
 }
 ```
 
@@ -331,7 +333,7 @@ To accomplish that, provide the following `loaders` value:
 
 ```js
 {
-  noExt: cosmiconfig.loadJson
+  noExt: defaultLoaders.loadJson
 }
 ```
 
@@ -369,7 +371,7 @@ You can also add a `sync` property to designate a sync loader, if you want to us
 A few things to note:
 
 - If you use a custom loader, be aware of whether it's sync or async and how that aligned with your usage of sync or async search and load functions.
-- **Special JS syntax can also be handled by using a `require` hook**, because `cosmiconfig.loadJs` just uses `require`.
+- **Special JS syntax can also be handled by using a `require` hook**, because `defaultLoaders.loadJs` just uses `require`.
   Whether you use custom loaders or a `require` hook is up to you.
 
 Examples:
@@ -399,9 +401,9 @@ Examples:
 
 // Allow many flavors of JS but rely on require hooks:
 {
-  '.mjs': cosmiconfig.loadJs,
-  '.ts': cosmiconfig.loadJs,
-  '.coffee': cosmiconfig.loadJs
+  '.mjs': defaultLoaders.loadJs,
+  '.ts': defaultLoaders.loadJs,
+  '.coffee': defaultLoaders.loadJs
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 import { createExplorer } from './createExplorer';
-import * as loaders from './loaders';
+import * as defaultLoaders from './loaders';
 import {
   Config,
   CosmiconfigResult,
@@ -63,17 +63,13 @@ function cosmiconfig(
   return createExplorer(normalizedOptions);
 }
 
-cosmiconfig.loadJs = loaders.loadJs;
-cosmiconfig.loadJson = loaders.loadJson;
-cosmiconfig.loadYaml = loaders.loadYaml;
-
 function normalizeLoaders(rawLoaders?: RawLoaders): Loaders {
   const defaults: Loaders = {
-    '.js': { sync: loaders.loadJs, async: loaders.loadJs },
-    '.json': { sync: loaders.loadJson, async: loaders.loadJson },
-    '.yaml': { sync: loaders.loadYaml, async: loaders.loadYaml },
-    '.yml': { sync: loaders.loadYaml, async: loaders.loadYaml },
-    noExt: { sync: loaders.loadYaml, async: loaders.loadYaml },
+    '.js': { sync: defaultLoaders.loadJs, async: defaultLoaders.loadJs },
+    '.json': { sync: defaultLoaders.loadJson, async: defaultLoaders.loadJson },
+    '.yaml': { sync: defaultLoaders.loadYaml, async: defaultLoaders.loadYaml },
+    '.yml': { sync: defaultLoaders.loadYaml, async: defaultLoaders.loadYaml },
+    noExt: { sync: defaultLoaders.loadYaml, async: defaultLoaders.loadYaml },
   };
 
   if (!rawLoaders) {
@@ -99,4 +95,4 @@ const identity: Transform = function identity(x) {
   return x;
 };
 
-export { cosmiconfig };
+export { cosmiconfig, defaultLoaders };

--- a/test/failed-directories.test.ts
+++ b/test/failed-directories.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { TempDir } from './util';
-import { cosmiconfig, Options } from '../src';
+import { cosmiconfig, defaultLoaders, Options } from '../src';
 
 const temp = new TempDir();
 
@@ -145,7 +145,7 @@ describe('throws error for invalid JSON in extensionless rc file loaded as JSON'
   const explorerOptions = {
     stopDir: temp.absolutePath('a'),
     loaders: {
-      noExt: cosmiconfig.loadJson,
+      noExt: defaultLoaders.loadJson,
     },
   };
 

--- a/test/successful-directories.test.ts
+++ b/test/successful-directories.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { TempDir } from './util';
-import { cosmiconfig } from '../src';
+import { cosmiconfig, defaultLoaders } from '../src';
 
 const temp = new TempDir();
 
@@ -351,7 +351,7 @@ describe('finds rc file in third searched dir, skipping packageProp, parsing ext
   const explorerOptions = {
     stopDir: temp.absolutePath('.'),
     loaders: {
-      noExt: cosmiconfig.loadJson,
+      noExt: defaultLoaders.loadJson,
     },
     searchPlaces: ['.foorc', 'foo.config.js'],
   };


### PR DESCRIPTION
Because named exports are used it makes sense to directly export the default loaders instead of attaching it to the actual `cosmiconfig` export.