### PR TITLE
Breaking: Use transformSync option for sync transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Migrate from Flowtype to Typescript
 - **Breaking change:** Remove support for Node 4 and 6. Requires Node 8+.
+- **Breaking change:** Use `transformSync` option for sync transform.
 - **Breaking change:** Use named export `cosmiconfig`. (see example below)
 
 ```js

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are still using v4, those v4 docs are available [in the `4.0.0` tag](http
   - [packageProp](#packageprop)
   - [stopDir](#stopdir)
   - [cache](#cache)
-  - [transform](#transform)
+  - [transform / transformSync](#transform--transformsync)
   - [ignoreEmptySearchPlaces](#ignoreemptysearchplaces)
 - [Caching](#caching)
 - [Differences from rc](#differences-from-rc)
@@ -462,14 +462,21 @@ Default: `true`.
 If `false`, no caches will be used.
 Read more about ["Caching"](#caching) below.
 
-### transform
-
-Type: `(Result) => Promise<Result> | Result`.
+### transform / transformSync
 
 A function that transforms the parsed configuration. Receives the [result].
 
-If using [`search()`] or [`load()`] \(which are async), the transform function can return the transformed result or return a Promise that resolves with the transformed result.
-If using [`searchSync()`] or [`loadSync()`], the function must be synchronous and return the transformed result.
+##### transform
+
+Type: `(Result) => Promise<Result> | Result`.
+
+If using [`search()`] or [`load()`] \(which are async), the `transform` function can return the transformed result or return a Promise that resolves with the transformed result.
+
+##### transformSync
+
+Type: `(Result) => Result`.
+
+If using [`searchSync()`] or [`loadSync()`], the `transformSync` function must be synchronous and return the transformed result.
 
 The reason you might use this option — instead of simply applying your transform function some other way — is that *the transformed result will be cached*. If your transformation involves additional filesystem I/O or other potentially slow processing, you can use this option to avoid repeating those steps every time a given configuration is searched or loaded.
 

--- a/src/createExplorer.ts
+++ b/src/createExplorer.ts
@@ -127,9 +127,8 @@ class Explorer {
         return this.searchFromDirectorySync(nextDir);
       }
 
-      const transformResult = this.config.transform(result);
+      const transformResult = this.config.transformSync(result);
 
-      // @ts-ignore
       return transformResult;
     };
 
@@ -353,9 +352,8 @@ class Explorer {
         content,
       );
 
-      const transformResult = this.config.transform(cosmiconfigResult);
+      const transformResult = this.config.transformSync(cosmiconfigResult);
 
-      // @ts-ignore
       return transformResult;
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,10 +19,12 @@ interface RawLoaders {
   [key: string]: LoaderEntry | LoaderSync | LoaderAsync;
 }
 
-// cannot return a promise with sync methods
-export type Transform = (
+export type Transform =
+  | ((CosmiconfigResult: CosmiconfigResult) => Promise<CosmiconfigResult>)
+  | TransformSync;
+export type TransformSync = (
   CosmiconfigResult: CosmiconfigResult,
-) => CosmiconfigResult | Promise<CosmiconfigResult>;
+) => CosmiconfigResult;
 
 export interface Options {
   packageProp?: string;
@@ -32,6 +34,7 @@ export interface Options {
   stopDir?: string;
   cache?: boolean;
   transform?: Transform;
+  transformSync?: TransformSync;
 }
 
 function cosmiconfig(
@@ -53,6 +56,7 @@ function cosmiconfig(
     stopDir: os.homedir(),
     cache: true,
     transform: identity,
+    transformSync: identity,
   };
   const normalizedOptions: ExplorerOptions = {
     ...defaults,
@@ -95,7 +99,7 @@ function normalizeLoaders(rawLoaders?: RawLoaders): Loaders {
   }, defaults);
 }
 
-const identity: Transform = function identity(x) {
+const identity: TransformSync = function identity(x) {
   return x;
 };
 

--- a/test/successful-files.test.ts
+++ b/test/successful-files.test.ts
@@ -1,5 +1,5 @@
 import { TempDir } from './util';
-import { cosmiconfig } from '../src';
+import { cosmiconfig, TransformSync } from '../src';
 
 const temp = new TempDir();
 
@@ -228,7 +228,7 @@ describe('runs transform', () => {
   });
 
   const configPath = temp.absolutePath('foo.json');
-  const transform = (result: any) => {
+  const transform: TransformSync = (result: any) => {
     result.config.foo = [result.config.foo];
     return result;
   };
@@ -245,7 +245,7 @@ describe('runs transform', () => {
 
   test('sync', () => {
     const result = cosmiconfig('successful-files-tests', {
-      transform,
+      transformSync: transform,
     }).loadSync(configPath);
     checkResult(result);
   });
@@ -258,7 +258,7 @@ describe('does not swallow transform errors', () => {
 
   const configPath = temp.absolutePath('foo.json');
   const expectedError = new Error('These pretzels are making me thirsty!');
-  const transform = () => {
+  const transform: TransformSync = () => {
     throw expectedError;
   };
 
@@ -270,7 +270,9 @@ describe('does not swallow transform errors', () => {
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('successful-files-tests', { transform }).loadSync(configPath),
+      cosmiconfig('successful-files-tests', {
+        transformSync: transform,
+      }).loadSync(configPath),
     ).toThrow(expectedError);
   });
 });


### PR DESCRIPTION
> I think there should be a way to have a sync and async transform. Also, there isn't a way to properly type the function at its current state.
> 
> Options:
> 
> - Use options object `{ sync: () => 'transformSync', async: async () => 'transformAsync' }`.
> - Add `transformSync` option.
> - Deprecate the direct `transform` option and add: `transformSync` / `transformAsync` options.
> - No API changes. Uncomment out `Promise<CosmiconfigResult>` and use `// @ts-ignore` comments to suppress any typescript errors. (not my preference)


Fixes https://github.com/davidtheclark/cosmiconfig/pull/197#discussion_r296317390 via `add transformSync option`.

It might be better to have the object only format:
```ts
const transform = {
	sync?: (result) => result,
	async?: async (result) => result,
}
```


