### PR TITLE
Separate async sync api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 ## HEAD
 
 - Migrate from Flowtype to Typescript
+
+- **Breaking change:** Replace `searchSync` with `cosmiconfigSync.search` and replace `loadSync` with `cosmiconfigSync.load`
+
+```js
+// cosmiconfig v5
+import { cosmiconfig } from 'cosmiconfig';
+
+const explorer = cosmiconfig('example');
+const searchAsyncResult = await explorer.search() 
+const loadAsyncResult = await explorer.load('./file/to/load') 
+const searchSyncResult = explorer.searchSync() 
+const loadSyncResult = explorer.loadSync('./file/to/load') 
+
+// cosmiconfig v6
+import { cosmiconfig, cosmiconfigSync } from 'cosmiconfig';
+
+const explorer = cosmiconfig('example');
+const searchAsyncResult = await explorer.search() 
+const loadAsyncResult = await explorer.load('./file/to/load') 
+
+const explorerSync = cosmiconfigSync('example');
+const searchSyncResult = explorerSync.search() 
+const loadSyncResult = explorerSync.load('./file/to/load') 
+```
+
 - **Breaking change:** Remove support for Node 4 and 6. Requires Node 8+.
 - **Breaking change:** Remove `cosmiconfig.loaders` and add named export `defaultLoaders`.
 - **Breaking change:** Use named export `cosmiconfig`. (see example below)

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ If you are still using v4, those v4 docs are available [in the `4.0.0` tag](http
   - [moduleName](#modulename)
 - [explorer.search()](#explorersearch)
   - [searchFrom](#searchfrom)
-- [explorer.searchSync()](#explorersearchsync)
+- [explorerSync.search()](#explorersyncsearch)
 - [explorer.load()](#explorerload)
-- [explorer.loadSync()](#explorerloadsync)
+- [explorerSync.load()](#explorersyncload)
 - [explorer.clearLoadCache()](#explorerclearloadcache)
 - [explorer.clearSearchCache()](#explorerclearsearchcache)
 - [explorer.clearCaches()](#explorerclearcaches)
@@ -70,7 +70,7 @@ Tested in Node 8+.
 Create a Cosmiconfig explorer, then either `search` for or directly `load` a configuration file.
 
 ```js
-const { cosmiconfig } = require('cosmiconfig');
+const { cosmiconfig, cosmiconfigSync } = require('cosmiconfig');
 // ...
 const explorer = cosmiconfig(moduleName);
 
@@ -92,8 +92,10 @@ explorer.search()
 explorer.load(pathToConfig).then(..);
 
 // You can also search and load synchronously.
-const searchedFor = explorer.searchSync();
-const loaded = explorer.loadSync(pathToConfig);
+const explorerSync = cosmiconfigSync(moduleName);
+
+const searchedFor = explorerSync.search();
+const loaded = explorerSync.load(pathToConfig);
 ```
 
 ## Result
@@ -131,7 +133,7 @@ explorer.search([searchFrom]).then(result => {..})
 
 Searches for a configuration file. Returns a Promise that resolves with a [result] or with `null`, if no configuration file is found.
 
-You can do the same thing synchronously with [`searchSync()`].
+You can do the same thing synchronously with [`cosmiconfigSync.search()`].
 
 Let's say your module name is `goldengrahams` so you initialized with `const explorer = cosmiconfig('goldengrahams');`.
 Here's how your default [`search()`] will work:
@@ -145,9 +147,9 @@ Here's how your default [`search()`] will work:
 - If none of those searches reveal a configuration object, move up one directory level and try again.
   So the search continues in `./`, `../`, `../../`, `../../../`, etc., checking the same places in each directory.
 - Continue searching until arriving at your home directory (or some other directory defined by the cosmiconfig option [`stopDir`]).
-- If at any point a parseable configuration is found, the [`search()`] Promise resolves with its [result] \(or, with [`searchSync()`], the [result] is returned).
-- If no configuration object is found, the [`search()`] Promise resolves with `null` (or, with [`searchSync()`], `null` is returned).
-- If a configuration object is found *but is malformed* (causing a parsing error), the [`search()`] Promise rejects with that error (so you should `.catch()` it). (Or, with [`searchSync()`], the error is thrown.)
+- If at any point a parsable configuration is found, the [`search()`] Promise resolves with its [result] \(or, with [`cosmiconfigSync.search()`], the [result] is returned).
+- If no configuration object is found, the [`search()`] Promise resolves with `null` (or, with [`cosmiconfigSync.search()`], `null` is returned).
+- If a configuration object is found *but is malformed* (causing a parsing error), the [`search()`] Promise rejects with that error (so you should `.catch()` it). (Or, with [`cosmiconfigSync.search()`], the error is thrown.)
 
 **If you know exactly where your configuration file should be, you can use [`load()`], instead.**
 
@@ -165,10 +167,10 @@ A filename.
 If the value is a directory, that's where the search starts.
 If it's a file, the search starts in that file's directory.
 
-## explorer.searchSync()
+## explorerSync.search()
 
 ```js
-const result = explorer.searchSync([searchFrom]);
+const result = explorerSync.search([searchFrom]);
 ```
 
 Synchronous version of [`search()`].
@@ -191,10 +193,10 @@ explorer.load('load/this/file.json'); // Tries to load load/this/file.json.
 
 If you load a `package.json` file, the result will be derived from whatever property is specified as your [`packageProp`].
 
-## explorer.loadSync()
+## explorerSync.load()
 
 ```js
-const result = explorer.loadSync(loadPath);
+const result = explorerSync.load(loadPath);
 ```
 
 Synchronous version of [`load()`].
@@ -326,7 +328,7 @@ So you can override one or two without having to override them all.
 
 **Keys in `loaders`** are extensions (starting with a period), or `noExt` to specify the loader for files *without* extensions, like `.soursocksrc`.
 
-**Values in `loaders`** are either a loader function (described below) or an object with `sync` and/or `async` properties, whose values are loader functions.
+**Values in `loaders`** are a loader function (described below) whose values are loader functions.
 
 **The most common use case for custom loaders value is to load extensionless `rc` files as strict JSON**, instead of JSON *or* YAML (the default).
 To accomplish that, provide the following `loaders` value:
@@ -364,9 +366,7 @@ Do whatever you need to, and return either a configuration object or `null` (or,
 `null` indicates that no real configuration was found and the search should continue.
 
 It's easiest if you make your custom loader function synchronous.
-Then it can be used regardless of whether you end up calling [`search()`] or [`searchSync()`], [`load()`] or [`loadSync()`].
-If you want or need to provide an async-only loader, you can do so by making the value of `loaders` an object with an `async` property whose value is the async loader.
-You can also add a `sync` property to designate a sync loader, if you want to use both async and sync search and load functions.
+Then it can be used regardless of whether you end up calling [`search()`], [`load()`].
 
 A few things to note:
 
@@ -380,11 +380,6 @@ Examples:
 // Allow JSON5 syntax:
 {
   '.json': json5Loader
-}
-
-// Allow XML, and treat sync and async separately:
-{
-  '.xml': { async: asyncXmlLoader, sync: syncXmlLoader }
 }
 
 // Allow a special configuration syntax of your own creation:
@@ -471,7 +466,7 @@ Type: `(Result) => Promise<Result> | Result`.
 A function that transforms the parsed configuration. Receives the [result].
 
 If using [`search()`] or [`load()`] \(which are async), the transform function can return the transformed result or return a Promise that resolves with the transformed result.
-If using [`searchSync()`] or [`loadSync()`], the function must be synchronous and return the transformed result.
+If using `cosmiconfigSync`, [`search()`] or [`load()`], the function must be synchronous and return the transformed result.
 
 The reason you might use this option — instead of simply applying your transform function some other way — is that *the transformed result will be cached*. If your transformation involves additional filesystem I/O or other potentially slow processing, you can use this option to avoid repeating those steps every time a given configuration is searched or loaded.
 
@@ -516,11 +511,11 @@ And please do participate!
 
 [`load()`]: #explorerload
 
-[`loadsync()`]: #explorerloadsync
+[`loadsync()`]: #explorersyncload
 
 [`search()`]: #explorersearch
 
-[`searchsync()`]: #explorersearchsync
+[`searchsync()`]: #explorersyncsearch
 
 [`clearloadcache()`]: #explorerclearloadcache
 

--- a/src/createExplorer.ts
+++ b/src/createExplorer.ts
@@ -1,80 +1,14 @@
 import path from 'path';
-import * as loaders from './loaders';
-import { readFile, readFileSync } from './readFile';
-import { cacheWrapper, cacheWrapperSync } from './cacheWrapper';
-import { getDirectory, getDirectorySync } from './getDirectory';
-import { getPropertyByPath } from './getPropertyByPath';
-import {
-  CosmiconfigResult,
-  ExplorerOptions,
-  LoaderEntry,
-  Config,
-  Cache,
-} from './types';
-import { LoaderAsync, LoaderSync } from './index';
+import { ExplorerBase, getExtensionDescription } from './createExplorerBase';
+import { readFile } from './readFile';
+import { cacheWrapper } from './cacheWrapper';
+import { getDirectory } from './getDirectory';
+import { CosmiconfigResult, ExplorerOptions, LoadedFileContent } from './types';
+import { LoaderAsync } from './index';
 
-// An object value represents a config object.
-// null represents that the loader did not find anything relevant.
-// undefined represents that the loader found something relevant
-// but it was empty.
-type LoadedFileContent = Config | null | undefined;
-
-class Explorer {
-  private readonly loadCache?: Cache;
-  private readonly loadSyncCache?: Cache;
-  private readonly searchCache?: Cache;
-  private readonly searchSyncCache?: Cache;
-  private readonly config: ExplorerOptions;
-
+class ExplorerAsync extends ExplorerBase<ExplorerOptions> {
   public constructor(options: ExplorerOptions) {
-    if (options.cache === true) {
-      this.loadCache = new Map();
-      this.loadSyncCache = new Map();
-      this.searchCache = new Map();
-      this.searchSyncCache = new Map();
-    }
-
-    this.config = options;
-    this.validateConfig();
-  }
-
-  public clearLoadCache(): void {
-    if (this.loadCache) {
-      this.loadCache.clear();
-    }
-    if (this.loadSyncCache) {
-      this.loadSyncCache.clear();
-    }
-  }
-
-  public clearSearchCache(): void {
-    if (this.searchCache) {
-      this.searchCache.clear();
-    }
-    if (this.searchSyncCache) {
-      this.searchSyncCache.clear();
-    }
-  }
-
-  public clearCaches(): void {
-    this.clearLoadCache();
-    this.clearSearchCache();
-  }
-
-  private validateConfig(): void {
-    const config = this.config;
-
-    config.searchPlaces.forEach((place): void => {
-      const loaderKey = path.extname(place) || 'noExt';
-      const loader = config.loaders[loaderKey];
-      if (!loader) {
-        throw new Error(
-          `No loader specified for ${getExtensionDescription(
-            place,
-          )}, so searchPlaces item "${place}" is invalid`,
-        );
-      }
-    });
+    super(options);
   }
 
   public async search(
@@ -82,13 +16,6 @@ class Explorer {
   ): Promise<CosmiconfigResult> {
     const startDirectory = await getDirectory(searchFrom);
     const result = await this.searchFromDirectory(startDirectory);
-
-    return result;
-  }
-
-  public searchSync(searchFrom: string = process.cwd()): CosmiconfigResult {
-    const startDirectory = getDirectorySync(searchFrom);
-    const result = this.searchFromDirectorySync(startDirectory);
 
     return result;
   }
@@ -116,30 +43,6 @@ class Explorer {
     return run();
   }
 
-  private searchFromDirectorySync(dir: string): CosmiconfigResult {
-    const absoluteDir = path.resolve(process.cwd(), dir);
-
-    const run = (): CosmiconfigResult => {
-      const result = this.searchDirectorySync(absoluteDir);
-      const nextDir = this.nextDirectoryToSearch(absoluteDir, result);
-
-      if (nextDir) {
-        return this.searchFromDirectorySync(nextDir);
-      }
-
-      const transformResult = this.config.transform(result);
-
-      // @ts-ignore
-      return transformResult;
-    };
-
-    if (this.searchSyncCache) {
-      return cacheWrapperSync(this.searchSyncCache, absoluteDir, run);
-    }
-
-    return run();
-  }
-
   private async searchDirectory(dir: string): Promise<CosmiconfigResult> {
     for await (const place of this.config.searchPlaces) {
       const placeResult = await this.loadSearchPlace(dir, place);
@@ -151,25 +54,6 @@ class Explorer {
 
     // config not found
     return null;
-  }
-
-  private searchDirectorySync(dir: string): CosmiconfigResult {
-    for (const place of this.config.searchPlaces) {
-      const placeResult = this.loadSearchPlaceSync(dir, place);
-
-      if (this.shouldSearchStopWithResult(placeResult) === true) {
-        return placeResult;
-      }
-    }
-
-    // config not found
-    return null;
-  }
-
-  private shouldSearchStopWithResult(result: CosmiconfigResult): boolean {
-    if (result === null) return false;
-    if (result.isEmpty && this.config.ignoreEmptySearchPlaces) return false;
-    return true;
   }
 
   private async loadSearchPlace(
@@ -184,48 +68,6 @@ class Explorer {
     return result;
   }
 
-  private loadSearchPlaceSync(dir: string, place: string): CosmiconfigResult {
-    const filepath = path.join(dir, place);
-    const content = readFileSync(filepath);
-
-    const result = this.createCosmiconfigResultSync(filepath, content);
-
-    return result;
-  }
-
-  private nextDirectoryToSearch(
-    currentDir: string,
-    currentResult: CosmiconfigResult,
-  ): string | null {
-    if (this.shouldSearchStopWithResult(currentResult)) {
-      return null;
-    }
-    const nextDir = nextDirUp(currentDir);
-    if (nextDir === currentDir || currentDir === this.config.stopDir) {
-      return null;
-    }
-    return nextDir;
-  }
-
-  private loadPackageProp(filepath: string, content: string): unknown {
-    const parsedContent = loaders.loadJson(filepath, content);
-    const packagePropValue = getPropertyByPath(
-      parsedContent,
-      this.config.packageProp,
-    );
-    return packagePropValue || null;
-  }
-
-  private getLoaderEntryForFile(filepath: string): LoaderEntry {
-    if (path.basename(filepath) === 'package.json') {
-      const loader = this.loadPackageProp.bind(this);
-      return { sync: loader, async: loader };
-    }
-
-    const loaderKey = path.extname(filepath) || 'noExt';
-    return this.config.loaders[loaderKey] || {};
-  }
-
   private getAsyncLoaderForFile(filepath: string): LoaderAsync {
     const entry = this.getLoaderEntryForFile(filepath);
     const loader = entry.async || entry.sync;
@@ -235,16 +77,6 @@ class Explorer {
       );
     }
     return loader;
-  }
-
-  private getSyncLoaderForFile(filepath: string): LoaderSync {
-    const entry = this.getLoaderEntryForFile(filepath);
-    if (!entry.sync) {
-      throw new Error(
-        `No sync loader specified for ${getExtensionDescription(filepath)}`,
-      );
-    }
-    return entry.sync;
   }
 
   private async loadFileContent(
@@ -262,34 +94,6 @@ class Explorer {
     return loaderResult;
   }
 
-  private loadFileContentSync(
-    filepath: string,
-    content: string | null,
-  ): LoadedFileContent {
-    if (content === null) {
-      return null;
-    }
-    if (content.trim() === '') {
-      return undefined;
-    }
-    const loader = this.getSyncLoaderForFile(filepath);
-    const loaderResult = loader(filepath, content);
-    return loaderResult;
-  }
-
-  private loadedContentToCosmiconfigResult(
-    filepath: string,
-    loadedContent: LoadedFileContent,
-  ): CosmiconfigResult {
-    if (loadedContent === null) {
-      return null;
-    }
-    if (loadedContent === undefined) {
-      return { filepath, config: undefined, isEmpty: true };
-    }
-    return { config: loadedContent, filepath };
-  }
-
   private async createCosmiconfigResult(
     filepath: string,
     content: string | null,
@@ -298,22 +102,6 @@ class Explorer {
     const result = this.loadedContentToCosmiconfigResult(filepath, fileContent);
 
     return result;
-  }
-
-  private createCosmiconfigResultSync(
-    filepath: string,
-    content: string | null,
-  ): CosmiconfigResult {
-    const fileContent = this.loadFileContentSync(filepath, content);
-    const result = this.loadedContentToCosmiconfigResult(filepath, fileContent);
-
-    return result;
-  }
-
-  private validateFilePath(filepath: string): void {
-    if (!filepath) {
-      throw new Error('load and loadSync must pass a non-empty string');
-    }
   }
 
   public async load(filepath: string): Promise<CosmiconfigResult> {
@@ -341,58 +129,19 @@ class Explorer {
 
     return runLoad();
   }
-
-  public loadSync(filepath: string): CosmiconfigResult {
-    this.validateFilePath(filepath);
-    const absoluteFilePath = path.resolve(process.cwd(), filepath);
-
-    const runLoadSync = (): CosmiconfigResult => {
-      const content = readFileSync(absoluteFilePath, { throwNotFound: true });
-      const cosmiconfigResult = this.createCosmiconfigResultSync(
-        absoluteFilePath,
-        content,
-      );
-
-      const transformResult = this.config.transform(cosmiconfigResult);
-
-      // @ts-ignore
-      return transformResult;
-    };
-
-    if (this.loadSyncCache) {
-      return cacheWrapperSync(
-        this.loadSyncCache,
-        absoluteFilePath,
-        runLoadSync,
-      );
-    }
-
-    return runLoadSync();
-  }
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function createExplorer(options: ExplorerOptions) {
-  const explorer = new Explorer(options);
+  const explorer = new ExplorerAsync(options);
 
   return {
     search: explorer.search.bind(explorer),
-    searchSync: explorer.searchSync.bind(explorer),
     load: explorer.load.bind(explorer),
-    loadSync: explorer.loadSync.bind(explorer),
     clearLoadCache: explorer.clearLoadCache.bind(explorer),
     clearSearchCache: explorer.clearSearchCache.bind(explorer),
     clearCaches: explorer.clearCaches.bind(explorer),
   } as const;
-}
-
-function nextDirUp(dir: string): string {
-  return path.dirname(dir);
-}
-
-function getExtensionDescription(filepath: string): string {
-  const ext = path.extname(filepath);
-  return ext ? `extension "${ext}"` : 'files without extensions';
 }
 
 export { createExplorer };

--- a/src/createExplorer.ts
+++ b/src/createExplorer.ts
@@ -1,10 +1,9 @@
 import path from 'path';
-import { ExplorerBase, getExtensionDescription } from './createExplorerBase';
+import { ExplorerBase } from './createExplorerBase';
 import { readFile } from './readFile';
 import { cacheWrapper } from './cacheWrapper';
 import { getDirectory } from './getDirectory';
 import { CosmiconfigResult, ExplorerOptions, LoadedFileContent } from './types';
-import { Loader } from './index';
 
 class ExplorerAsync extends ExplorerBase<ExplorerOptions> {
   public constructor(options: ExplorerOptions) {
@@ -68,16 +67,6 @@ class ExplorerAsync extends ExplorerBase<ExplorerOptions> {
     return result;
   }
 
-  private getAsyncLoaderForFile(filepath: string): Loader {
-    const loader = this.getLoaderEntryForFile(filepath);
-    if (!loader) {
-      throw new Error(
-        `No async loader specified for ${getExtensionDescription(filepath)}`,
-      );
-    }
-    return loader;
-  }
-
   private async loadFileContent(
     filepath: string,
     content: string | null,
@@ -88,7 +77,7 @@ class ExplorerAsync extends ExplorerBase<ExplorerOptions> {
     if (content.trim() === '') {
       return undefined;
     }
-    const loader = this.getAsyncLoaderForFile(filepath);
+    const loader = this.getLoaderEntryForFile(filepath);
     const loaderResult = await loader(filepath, content);
     return loaderResult;
   }

--- a/src/createExplorer.ts
+++ b/src/createExplorer.ts
@@ -4,7 +4,7 @@ import { readFile } from './readFile';
 import { cacheWrapper } from './cacheWrapper';
 import { getDirectory } from './getDirectory';
 import { CosmiconfigResult, ExplorerOptions, LoadedFileContent } from './types';
-import { LoaderAsync } from './index';
+import { Loader } from './index';
 
 class ExplorerAsync extends ExplorerBase<ExplorerOptions> {
   public constructor(options: ExplorerOptions) {
@@ -68,9 +68,8 @@ class ExplorerAsync extends ExplorerBase<ExplorerOptions> {
     return result;
   }
 
-  private getAsyncLoaderForFile(filepath: string): LoaderAsync {
-    const entry = this.getLoaderEntryForFile(filepath);
-    const loader = entry.async || entry.sync;
+  private getAsyncLoaderForFile(filepath: string): Loader {
+    const loader = this.getLoaderEntryForFile(filepath);
     if (!loader) {
       throw new Error(
         `No async loader specified for ${getExtensionDescription(filepath)}`,

--- a/src/createExplorerBase.ts
+++ b/src/createExplorerBase.ts
@@ -1,0 +1,129 @@
+import path from 'path';
+import * as loaders from './loaders';
+import { getPropertyByPath } from './getPropertyByPath';
+import {
+  CosmiconfigResult,
+  ExplorerOptions,
+  ExplorerOptionsSync,
+  LoaderEntry,
+  Cache,
+  LoadedFileContent,
+} from './types';
+
+class ExplorerBase<T extends ExplorerOptions | ExplorerOptionsSync> {
+  protected readonly loadCache?: Cache;
+  protected readonly searchCache?: Cache;
+  protected readonly config: T;
+
+  public constructor(options: T) {
+    if (options.cache === true) {
+      this.loadCache = new Map();
+      this.searchCache = new Map();
+    }
+
+    this.config = options;
+    this.validateConfig();
+  }
+
+  public clearLoadCache(): void {
+    if (this.loadCache) {
+      this.loadCache.clear();
+    }
+  }
+
+  public clearSearchCache(): void {
+    if (this.searchCache) {
+      this.searchCache.clear();
+    }
+  }
+
+  public clearCaches(): void {
+    this.clearLoadCache();
+    this.clearSearchCache();
+  }
+
+  private validateConfig(): void {
+    const config = this.config;
+
+    config.searchPlaces.forEach((place): void => {
+      const loaderKey = path.extname(place) || 'noExt';
+      const loader = config.loaders[loaderKey];
+      if (!loader) {
+        throw new Error(
+          `No loader specified for ${getExtensionDescription(
+            place,
+          )}, so searchPlaces item "${place}" is invalid`,
+        );
+      }
+    });
+  }
+
+  protected shouldSearchStopWithResult(result: CosmiconfigResult): boolean {
+    if (result === null) return false;
+    if (result.isEmpty && this.config.ignoreEmptySearchPlaces) return false;
+    return true;
+  }
+
+  protected nextDirectoryToSearch(
+    currentDir: string,
+    currentResult: CosmiconfigResult,
+  ): string | null {
+    if (this.shouldSearchStopWithResult(currentResult)) {
+      return null;
+    }
+    const nextDir = nextDirUp(currentDir);
+    if (nextDir === currentDir || currentDir === this.config.stopDir) {
+      return null;
+    }
+    return nextDir;
+  }
+
+  private loadPackageProp(filepath: string, content: string): unknown {
+    const parsedContent = loaders.loadJson(filepath, content);
+    const packagePropValue = getPropertyByPath(
+      parsedContent,
+      this.config.packageProp,
+    );
+    return packagePropValue || null;
+  }
+
+  protected getLoaderEntryForFile(filepath: string): LoaderEntry {
+    if (path.basename(filepath) === 'package.json') {
+      const loader = this.loadPackageProp.bind(this);
+      return { sync: loader, async: loader };
+    }
+
+    const loaderKey = path.extname(filepath) || 'noExt';
+    return this.config.loaders[loaderKey] || {};
+  }
+
+  protected loadedContentToCosmiconfigResult(
+    filepath: string,
+    loadedContent: LoadedFileContent,
+  ): CosmiconfigResult {
+    if (loadedContent === null) {
+      return null;
+    }
+    if (loadedContent === undefined) {
+      return { filepath, config: undefined, isEmpty: true };
+    }
+    return { config: loadedContent, filepath };
+  }
+
+  protected validateFilePath(filepath: string): void {
+    if (!filepath) {
+      throw new Error('load and loadSync must pass a non-empty string');
+    }
+  }
+}
+
+function nextDirUp(dir: string): string {
+  return path.dirname(dir);
+}
+
+function getExtensionDescription(filepath: string): string {
+  const ext = path.extname(filepath);
+  return ext ? `extension "${ext}"` : 'files without extensions';
+}
+
+export { ExplorerBase, getExtensionDescription };

--- a/src/createExplorerBase.ts
+++ b/src/createExplorerBase.ts
@@ -95,14 +95,23 @@ class ExplorerBase<T extends ExplorerOptions | ExplorerOptionsSync> {
     return packagePropValue || null;
   }
 
-  protected getLoaderEntryForFile(filepath: string): Loader | undefined {
+  protected getLoaderEntryForFile(filepath: string): Loader {
     if (path.basename(filepath) === 'package.json') {
       const loader = this.loadPackageProp.bind(this);
       return loader;
     }
 
     const loaderKey = path.extname(filepath) || 'noExt';
-    return this.config.loaders[loaderKey];
+
+    const loader = this.config.loaders[loaderKey];
+
+    if (!loader) {
+      throw new Error(
+        `No loader specified for ${getExtensionDescription(filepath)}`,
+      );
+    }
+
+    return loader;
   }
 
   protected loadedContentToCosmiconfigResult(

--- a/src/createExplorerSync.ts
+++ b/src/createExplorerSync.ts
@@ -1,0 +1,142 @@
+import path from 'path';
+import { ExplorerBase, getExtensionDescription } from './createExplorerBase';
+import { readFileSync } from './readFile';
+import { cacheWrapperSync } from './cacheWrapper';
+import { getDirectorySync } from './getDirectory';
+import {
+  CosmiconfigResult,
+  ExplorerOptionsSync,
+  LoadedFileContent,
+} from './types';
+import { LoaderSync } from './index';
+
+class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
+  public constructor(options: ExplorerOptionsSync) {
+    super(options);
+  }
+
+  public searchSync(searchFrom: string = process.cwd()): CosmiconfigResult {
+    const startDirectory = getDirectorySync(searchFrom);
+    const result = this.searchFromDirectorySync(startDirectory);
+
+    return result;
+  }
+
+  private searchFromDirectorySync(dir: string): CosmiconfigResult {
+    const absoluteDir = path.resolve(process.cwd(), dir);
+
+    const run = (): CosmiconfigResult => {
+      const result = this.searchDirectorySync(absoluteDir);
+      const nextDir = this.nextDirectoryToSearch(absoluteDir, result);
+
+      if (nextDir) {
+        return this.searchFromDirectorySync(nextDir);
+      }
+
+      const transformResult = this.config.transform(result);
+
+      return transformResult;
+    };
+
+    if (this.searchCache) {
+      return cacheWrapperSync(this.searchCache, absoluteDir, run);
+    }
+
+    return run();
+  }
+
+  private searchDirectorySync(dir: string): CosmiconfigResult {
+    for (const place of this.config.searchPlaces) {
+      const placeResult = this.loadSearchPlaceSync(dir, place);
+
+      if (this.shouldSearchStopWithResult(placeResult) === true) {
+        return placeResult;
+      }
+    }
+
+    // config not found
+    return null;
+  }
+
+  private loadSearchPlaceSync(dir: string, place: string): CosmiconfigResult {
+    const filepath = path.join(dir, place);
+    const content = readFileSync(filepath);
+
+    const result = this.createCosmiconfigResultSync(filepath, content);
+
+    return result;
+  }
+
+  private getSyncLoaderForFile(filepath: string): LoaderSync {
+    const entry = this.getLoaderEntryForFile(filepath);
+    if (!entry.sync) {
+      throw new Error(
+        `No sync loader specified for ${getExtensionDescription(filepath)}`,
+      );
+    }
+    return entry.sync;
+  }
+
+  private loadFileContentSync(
+    filepath: string,
+    content: string | null,
+  ): LoadedFileContent {
+    if (content === null) {
+      return null;
+    }
+    if (content.trim() === '') {
+      return undefined;
+    }
+    const loader = this.getSyncLoaderForFile(filepath);
+    const loaderResult = loader(filepath, content);
+    return loaderResult;
+  }
+
+  private createCosmiconfigResultSync(
+    filepath: string,
+    content: string | null,
+  ): CosmiconfigResult {
+    const fileContent = this.loadFileContentSync(filepath, content);
+    const result = this.loadedContentToCosmiconfigResult(filepath, fileContent);
+
+    return result;
+  }
+
+  public loadSync(filepath: string): CosmiconfigResult {
+    this.validateFilePath(filepath);
+    const absoluteFilePath = path.resolve(process.cwd(), filepath);
+
+    const runLoadSync = (): CosmiconfigResult => {
+      const content = readFileSync(absoluteFilePath, { throwNotFound: true });
+      const cosmiconfigResult = this.createCosmiconfigResultSync(
+        absoluteFilePath,
+        content,
+      );
+
+      const transformResult = this.config.transform(cosmiconfigResult);
+
+      return transformResult;
+    };
+
+    if (this.loadCache) {
+      return cacheWrapperSync(this.loadCache, absoluteFilePath, runLoadSync);
+    }
+
+    return runLoadSync();
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function createExplorerSync(options: ExplorerOptionsSync) {
+  const explorer = new ExplorerSync(options);
+
+  return {
+    searchSync: explorer.searchSync.bind(explorer),
+    loadSync: explorer.loadSync.bind(explorer),
+    clearLoadCache: explorer.clearLoadCache.bind(explorer),
+    clearSearchCache: explorer.clearSearchCache.bind(explorer),
+    clearCaches: explorer.clearCaches.bind(explorer),
+  } as const;
+}
+
+export { createExplorerSync };

--- a/src/createExplorerSync.ts
+++ b/src/createExplorerSync.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { ExplorerBase, getExtensionDescription } from './createExplorerBase';
+import { ExplorerBase } from './createExplorerBase';
 import { readFileSync } from './readFile';
 import { cacheWrapperSync } from './cacheWrapper';
 import { getDirectorySync } from './getDirectory';
@@ -8,7 +8,6 @@ import {
   ExplorerOptionsSync,
   LoadedFileContent,
 } from './types';
-import { LoaderSync } from './index';
 
 class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
   public constructor(options: ExplorerOptionsSync) {
@@ -67,17 +66,6 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
     return result;
   }
 
-  private getSyncLoaderForFile(filepath: string): LoaderSync {
-    const loader = this.getLoaderEntryForFile(filepath);
-
-    if (!loader) {
-      throw new Error(
-        `No sync loader specified for ${getExtensionDescription(filepath)}`,
-      );
-    }
-    return loader;
-  }
-
   private loadFileContentSync(
     filepath: string,
     content: string | null,
@@ -88,7 +76,7 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
     if (content.trim() === '') {
       return undefined;
     }
-    const loader = this.getSyncLoaderForFile(filepath);
+    const loader = this.getLoaderEntryForFile(filepath);
     const loaderResult = loader(filepath, content);
 
     return loaderResult;

--- a/src/createExplorerSync.ts
+++ b/src/createExplorerSync.ts
@@ -68,13 +68,14 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
   }
 
   private getSyncLoaderForFile(filepath: string): LoaderSync {
-    const entry = this.getLoaderEntryForFile(filepath);
-    if (!entry.sync) {
+    const loader = this.getLoaderEntryForFile(filepath);
+
+    if (!loader) {
       throw new Error(
         `No sync loader specified for ${getExtensionDescription(filepath)}`,
       );
     }
-    return entry.sync;
+    return loader;
   }
 
   private loadFileContentSync(
@@ -89,6 +90,7 @@ class ExplorerSync extends ExplorerBase<ExplorerOptionsSync> {
     }
     const loader = this.getSyncLoaderForFile(filepath);
     const loaderResult = loader(filepath, content);
+
     return loaderResult;
   }
 
@@ -131,8 +133,8 @@ function createExplorerSync(options: ExplorerOptionsSync) {
   const explorer = new ExplorerSync(options);
 
   return {
-    searchSync: explorer.searchSync.bind(explorer),
-    loadSync: explorer.loadSync.bind(explorer),
+    search: explorer.searchSync.bind(explorer),
+    load: explorer.loadSync.bind(explorer),
     clearLoadCache: explorer.clearLoadCache.bind(explorer),
     clearSearchCache: explorer.clearSearchCache.bind(explorer),
     clearCaches: explorer.clearCaches.bind(explorer),

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -2,6 +2,7 @@ import parseJson from 'parse-json';
 import yaml from 'js-yaml';
 import importFresh from 'import-fresh';
 import { LoaderSync } from './index';
+import { LoadersSync } from './types';
 
 const loadJs: LoaderSync = function loadJs(filepath) {
   const result = importFresh(filepath);
@@ -21,4 +22,6 @@ const loadYaml: LoaderSync = function loadYaml(filepath, content) {
   return yaml.safeLoad(content, { filename: filepath });
 };
 
-export { loadJs, loadJson, loadYaml };
+const loaders: LoadersSync = { loadJs, loadJson, loadYaml };
+
+export { loaders };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Options, OptionsSync, LoaderAsync, LoaderSync } from './index';
+import { Loader, LoaderSync, Options, OptionsSync } from './index';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Config = any;
@@ -9,24 +9,11 @@ export type CosmiconfigResult = {
   isEmpty?: boolean;
 } | null;
 
-export interface LoaderEntry {
-  sync?: LoaderSync;
-  async?: LoaderAsync;
-}
-
-export interface Loaders {
-  [key: string]: LoaderEntry;
-}
-
 // These are the user options with defaults applied.
-export interface ExplorerOptions extends Required<Options> {
-  loaders: Loaders;
-}
-
-// These are the user options with defaults applied.
-export interface ExplorerOptionsSync extends Required<OptionsSync> {
-  loaders: Loaders;
-}
+/* eslint-disable @typescript-eslint/no-empty-interface */
+export interface ExplorerOptions extends Required<Options> {}
+export interface ExplorerOptionsSync extends Required<OptionsSync> {}
+/* eslint-enable @typescript-eslint/no-empty-interface */
 
 export type Cache = Map<string, CosmiconfigResult>;
 
@@ -35,3 +22,11 @@ export type Cache = Map<string, CosmiconfigResult>;
 // undefined represents that the loader found something relevant
 // but it was empty.
 export type LoadedFileContent = Config | null | undefined;
+
+export interface Loaders {
+  [key: string]: Loader;
+}
+
+export interface LoadersSync {
+  [key: string]: LoaderSync;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Options, LoaderAsync, LoaderSync } from './index';
+import { Options, OptionsSync, LoaderAsync, LoaderSync } from './index';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Config = any;
@@ -23,4 +23,15 @@ export interface ExplorerOptions extends Required<Options> {
   loaders: Loaders;
 }
 
+// These are the user options with defaults applied.
+export interface ExplorerOptionsSync extends Required<OptionsSync> {
+  loaders: Loaders;
+}
+
 export type Cache = Map<string, CosmiconfigResult>;
+
+// An object value represents a config object.
+// null represents that the loader did not find anything relevant.
+// undefined represents that the loader found something relevant
+// but it was empty.
+export type LoadedFileContent = Config | null | undefined;

--- a/test/caches.test.ts
+++ b/test/caches.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import importFreshActual from 'import-fresh';
 import { TempDir } from './util';
-import { cosmiconfig } from '../src';
+import { cosmiconfig, cosmiconfigSync } from '../src';
 
 // mocks are hoisted
 jest.mock('import-fresh');
@@ -59,7 +59,7 @@ describe('cache is not used initially', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const cachedSearchSync = cosmiconfig('foo').searchSync;
+    const cachedSearchSync = cosmiconfigSync('foo').search;
     const result = cachedSearchSync(searchPath);
     checkResult(readFileSpy, result);
   });
@@ -90,7 +90,7 @@ describe('cache is used for already-visited directories', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const cachedSearchSync = cosmiconfig('foo').searchSync;
+    const cachedSearchSync = cosmiconfigSync('foo').search;
     // First pass, prime the cache ...
     cachedSearchSync(searchPath);
     // Reset readFile mocks and search again.
@@ -126,7 +126,7 @@ describe('cache is used for already-loaded file', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const cachedLoadSync = cosmiconfig('foo').loadSync;
+    const cachedLoadSync = cosmiconfigSync('foo').load;
     // First pass, prime the cache ...
     cachedLoadSync(loadPath);
     // Reset readFile mocks and search again.
@@ -172,7 +172,7 @@ describe('cache is used when some directories in search are already visted', () 
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const cachedSearchSync = cosmiconfig('foo').searchSync;
+    const cachedSearchSync = cosmiconfigSync('foo').search;
     // First pass, prime the cache ...
     cachedSearchSync(firstSearchPath);
     // Reset readFile mocks and search again.
@@ -209,13 +209,13 @@ describe('cache is not used when directly loading an unvisited file', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const explorer = cosmiconfig('foo');
+    const explorer = cosmiconfigSync('foo');
     // First pass, prime the cache ...
-    explorer.searchSync(firstSearchPath);
+    explorer.search(firstSearchPath);
     // Reset readFile mocks and search again.
     readFileSpy.mockClear();
 
-    const result = explorer.loadSync(loadPath);
+    const result = explorer.load(loadPath);
     checkResult(readFileSpy, result);
   });
 });
@@ -256,11 +256,11 @@ describe('cache is not used in a new cosmiconfig instance', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
     // First pass, prime the cache ...
-    cosmiconfig('foo').searchSync(searchPath);
+    cosmiconfigSync('foo').search(searchPath);
     // Reset readFile mocks and search again.
     readFileSpy.mockClear();
 
-    const result = cosmiconfig('foo').searchSync(searchPath);
+    const result = cosmiconfigSync('foo').search(searchPath);
     checkResult(readFileSpy, result);
   });
 });
@@ -290,13 +290,13 @@ describe('clears file cache on calling clearLoadCache', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const explorer = cosmiconfig('foo');
-    explorer.loadSync(loadPath);
+    const explorer = cosmiconfigSync('foo');
+    explorer.load(loadPath);
     // Reset readFile mocks and search again.
     readFileSpy.mockClear();
     explorer.clearLoadCache();
 
-    const result = explorer.loadSync(loadPath);
+    const result = explorer.load(loadPath);
     checkResult(readFileSpy, result);
   });
 });
@@ -326,12 +326,12 @@ describe('clears file cache on calling clearCaches', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const explorer = cosmiconfig('foo');
-    explorer.loadSync(loadPath);
+    const explorer = cosmiconfigSync('foo');
+    explorer.load(loadPath);
     // Reset readFile mocks and search again.
     readFileSpy.mockClear();
     explorer.clearCaches();
-    const result = explorer.loadSync(loadPath);
+    const result = explorer.load(loadPath);
     checkResult(readFileSpy, result);
   });
 });
@@ -371,13 +371,13 @@ describe('clears directory cache on calling clearSearchCache', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const explorer = cosmiconfig('foo');
-    explorer.searchSync(searchPath);
+    const explorer = cosmiconfigSync('foo');
+    explorer.search(searchPath);
     // Reset readFile mocks and search again.
     readFileSpy.mockClear();
     explorer.clearSearchCache();
 
-    const result = explorer.searchSync(searchPath);
+    const result = explorer.search(searchPath);
     checkResult(readFileSpy, result);
   });
 });
@@ -417,13 +417,13 @@ describe('clears directory cache on calling clearCaches', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const explorer = cosmiconfig('foo');
-    explorer.searchSync(searchPath);
+    const explorer = cosmiconfigSync('foo');
+    explorer.search(searchPath);
     // Reset readFile mocks and search again.
     readFileSpy.mockClear();
     explorer.clearCaches();
 
-    const result = explorer.searchSync(searchPath);
+    const result = explorer.search(searchPath);
     checkResult(readFileSpy, result);
   });
 });
@@ -478,11 +478,11 @@ describe('with cache disabled, does not cache directory results', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const explorer = cosmiconfig('foo', { cache: false });
-    explorer.searchSync(searchPath);
+    const explorer = cosmiconfigSync('foo', { cache: false });
+    explorer.search(searchPath);
     readFileSpy.mockClear();
 
-    const result = explorer.searchSync(searchPath);
+    const result = explorer.search(searchPath);
     checkResult(readFileSpy, result);
   });
 });
@@ -511,11 +511,11 @@ describe('with cache disabled, does not cache file results', () => {
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const explorer = cosmiconfig('foo', { cache: false });
-    explorer.loadSync(loadPath);
+    const explorer = cosmiconfigSync('foo', { cache: false });
+    explorer.load(loadPath);
     readFileSpy.mockClear();
 
-    const result = explorer.loadSync(loadPath);
+    const result = explorer.load(loadPath);
     checkResult(readFileSpy, result);
   });
 });
@@ -544,10 +544,10 @@ describe('ensure import-fresh is called when loading a js file', () => {
   });
 
   test('sync', () => {
-    const explorer = cosmiconfig('foo');
+    const explorer = cosmiconfigSync('foo');
     temp.createFile(tempFileName, 'module.exports = { foundJs: true };');
 
-    const result = explorer.loadSync(loadPath);
+    const result = explorer.load(loadPath);
     checkResult(result);
   });
 });

--- a/test/failed-directories.test.ts
+++ b/test/failed-directories.test.ts
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import { TempDir } from './util';
-import { cosmiconfig, defaultLoaders, Options } from '../src';
+import {
+  cosmiconfig,
+  cosmiconfigSync,
+  defaultLoaders,
+  OptionsSync,
+} from '../src';
 
 const temp = new TempDir();
 
@@ -66,7 +71,7 @@ describe('gives up if it cannot find the file', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
     const statSpy = jest.spyOn(fs, 'statSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(statSpy, readFileSpy, result);
   });
 });
@@ -107,7 +112,7 @@ describe('stops at stopDir and gives up', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -131,7 +136,7 @@ describe('throws error for invalid YAML in rc file', () => {
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('foo', explorerOptions).searchSync(startDir),
+      cosmiconfigSync('foo', explorerOptions).search(startDir),
     ).toThrow(expectedError);
   });
 });
@@ -159,7 +164,7 @@ describe('throws error for invalid JSON in extensionless rc file loaded as JSON'
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('foo', explorerOptions).searchSync(startDir),
+      cosmiconfigSync('foo', explorerOptions).search(startDir),
     ).toThrow(expectedError);
   });
 });
@@ -182,7 +187,7 @@ describe('throws error for invalid package.json', () => {
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('foo', explorerOptions).searchSync(startDir),
+      cosmiconfigSync('foo', explorerOptions).search(startDir),
     ).toThrow(expectedError);
   });
 });
@@ -208,7 +213,7 @@ describe('throws error for invalid JS in .config.js file', () => {
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('foo', explorerOptions).searchSync(startDir),
+      cosmiconfigSync('foo', explorerOptions).search(startDir),
     ).toThrow(expectedError);
   });
 });
@@ -233,7 +238,7 @@ describe('throws error for invalid JSON in .foorc.json', () => {
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('foo', explorerOptions).searchSync(startDir),
+      cosmiconfigSync('foo', explorerOptions).search(startDir),
     ).toThrow(expectedError);
   });
 });
@@ -259,7 +264,7 @@ describe('throws error for invalid YAML in .foorc.yml', () => {
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('foo', explorerOptions).searchSync(startDir),
+      cosmiconfigSync('foo', explorerOptions).search(startDir),
     ).toThrow(expectedError);
   });
 });
@@ -293,7 +298,7 @@ describe('searching for rc files with specified extensions, throws error for inv
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('foo', explorerOptions).searchSync(startDir),
+      cosmiconfigSync('foo', explorerOptions).search(startDir),
     ).toThrow(expectedError);
   });
 });
@@ -323,7 +328,7 @@ describe('without ignoring empty files, returns an empty config result for an em
   });
 
   test('sync', () => {
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(result);
   });
 });
@@ -353,7 +358,7 @@ describe('without ignoring empty files, returns an empty config result for an em
   });
 
   test('sync', () => {
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(result);
   });
 });
@@ -383,7 +388,7 @@ describe('without ignoring empty files, returns an empty config result for an em
   });
 
   test('sync', () => {
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(result);
   });
 });
@@ -413,7 +418,7 @@ describe('returns an empty config result for an empty .yaml rc file', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(result);
   });
 });
@@ -452,7 +457,7 @@ describe('without ignoring empty configs and searching for rc files with specifi
   });
 
   test('sync', () => {
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(result);
   });
 });
@@ -491,7 +496,7 @@ describe('without ignoring empty configs and searching for rc files with specifi
   });
 
   test('sync', () => {
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(result);
   });
 });
@@ -509,7 +514,7 @@ describe('throws error if a file in searchPlaces does not have a corresponding l
   };
 
   test('on instantiation', () => {
-    expect(() => cosmiconfig('foo', explorerOptions)).toThrow(
+    expect(() => cosmiconfigSync('foo', explorerOptions)).toThrow(
       'No loader specified for extension ".things"',
     );
   });
@@ -520,7 +525,7 @@ describe('throws error if an extensionless file in searchPlaces does not have a 
     temp.createFile('a/b/c/d/e/f/.foorc', '{ "foo": "bar" }');
   });
 
-  const explorerOptions: Options = {
+  const explorerOptions: OptionsSync = {
     stopDir: temp.absolutePath('.'),
     searchPlaces: ['package.json', '.foorc'],
     // @ts-ignore
@@ -530,7 +535,7 @@ describe('throws error if an extensionless file in searchPlaces does not have a 
   };
 
   test('on instantiation', () => {
-    expect(() => cosmiconfig('foo', explorerOptions)).toThrow(
+    expect(() => cosmiconfigSync('foo', explorerOptions)).toThrow(
       'No loader specified for files without extensions',
     );
   });
@@ -563,7 +568,7 @@ describe('does not swallow errors from custom loaders', () => {
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('foo', explorerOptions).searchSync(startDir),
+      cosmiconfigSync('foo', explorerOptions).search(startDir),
     ).toThrow(expectedError);
   });
 });
@@ -587,7 +592,7 @@ describe('errors not swallowed when async custom loader throws them', () => {
     stopDir: temp.absolutePath('.'),
     searchPlaces: ['.foorc.things'],
     loaders: {
-      '.things': { async: loadThingsAsync },
+      '.things': loadThingsAsync,
     },
   };
 
@@ -617,7 +622,7 @@ describe('errors not swallowed when async custom loader rejects', () => {
     stopDir: temp.absolutePath('.'),
     searchPlaces: ['.foorc.things'],
     loaders: {
-      '.things': { async: loadThingsAsync },
+      '.things': loadThingsAsync,
     },
   };
 
@@ -625,60 +630,5 @@ describe('errors not swallowed when async custom loader rejects', () => {
     await expect(
       cosmiconfig('foo', explorerOptions).search(startDir),
     ).rejects.toThrow(expectedError);
-  });
-});
-
-describe('errors if only async loader is set but you call sync search', () => {
-  const startDir = temp.absolutePath('a/b/c/d/e/f');
-
-  beforeEach(() => {
-    temp.createFile(
-      'a/b/c/d/e/f/.foorc.things',
-      'one\ntwo\nthree\t\t\n  four\n',
-    );
-  });
-
-  const loadThings = async () => ({ things: true });
-
-  const explorerOptions = {
-    stopDir: temp.absolutePath('.'),
-    searchPlaces: ['.foorc.things'],
-    loaders: {
-      '.things': { async: loadThings },
-    },
-  };
-
-  test('sync', () => {
-    expect(() =>
-      cosmiconfig('foo', explorerOptions).searchSync(startDir),
-    ).toThrow('No sync loader specified for extension ".things"');
-  });
-});
-
-describe('errors if it cannot figure out an async loader', () => {
-  const startDir = temp.absolutePath('a/b/c/d/e/f');
-
-  beforeEach(() => {
-    temp.createFile(
-      'a/b/c/d/e/f/.foorc.things',
-      'one\ntwo\nthree\t\t\n  four\n',
-    );
-  });
-
-  const loadThings = async () => ({ things: true });
-
-  const explorerOptions: Options = {
-    stopDir: temp.absolutePath('.'),
-    searchPlaces: ['.foorc.things'],
-    loaders: {
-      // @ts-ignore
-      '.things': { wawa: loadThings },
-    },
-  };
-
-  test('async', async () => {
-    await expect(
-      cosmiconfig('foo', explorerOptions).search(startDir),
-    ).rejects.toThrow('No async loader specified for extension ".things"');
   });
 });

--- a/test/failed-files.test.ts
+++ b/test/failed-files.test.ts
@@ -1,5 +1,5 @@
 import { TempDir } from './util';
-import { cosmiconfig } from '../src';
+import { cosmiconfig, cosmiconfigSync } from '../src';
 
 const temp = new TempDir();
 
@@ -27,7 +27,7 @@ describe('throws error if defined file does not exist', () => {
   });
 
   test('sync', () => {
-    expect(() => cosmiconfig('failed-files-tests').loadSync(file)).toThrow(
+    expect(() => cosmiconfigSync('failed-files-tests').load(file)).toThrow(
       expectedError,
     );
   });
@@ -48,7 +48,7 @@ describe('throws error if defined JSON file has syntax error', () => {
   });
 
   test('sync', () => {
-    expect(() => cosmiconfig('failed-files-tests').loadSync(file)).toThrow(
+    expect(() => cosmiconfigSync('failed-files-tests').load(file)).toThrow(
       expectedError,
     );
   });
@@ -70,7 +70,7 @@ describe('throws error if defined YAML file has syntax error', () => {
   });
 
   test('sync', () => {
-    expect(() => cosmiconfig('failed-files-tests').loadSync(file)).toThrow(
+    expect(() => cosmiconfigSync('failed-files-tests').load(file)).toThrow(
       expectedError,
     );
   });
@@ -91,7 +91,7 @@ describe('throws error if defined JS file has syntax error', () => {
   });
 
   test('sync', () => {
-    expect(() => cosmiconfig('failed-files-tests').loadSync(file)).toThrow(
+    expect(() => cosmiconfigSync('failed-files-tests').load(file)).toThrow(
       expectedError,
     );
   });
@@ -117,7 +117,7 @@ describe('returns an empty config result for empty file, format JS', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('failed-files-tests').loadSync(file);
+    const result = cosmiconfigSync('failed-files-tests').load(file);
     checkResult(result);
   });
 });
@@ -142,7 +142,7 @@ describe('returns an empty config result for empty file, format JSON', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('failed-files-tests').loadSync(file);
+    const result = cosmiconfigSync('failed-files-tests').load(file);
     checkResult(result);
   });
 });
@@ -167,13 +167,13 @@ describe('returns an empty config result for empty file, format YAML', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('failed-files-tests').loadSync(file);
+    const result = cosmiconfigSync('failed-files-tests').load(file);
     checkResult(result);
   });
 });
 
 describe('throws an error if no configPath was specified and load is called without an argument', () => {
-  const expectedError = 'load and loadSync must pass a non-empty string';
+  const expectedError = 'load must pass a non-empty string';
 
   test('async', async () => {
     // @ts-ignore
@@ -184,7 +184,7 @@ describe('throws an error if no configPath was specified and load is called with
 
   test('sync', () => {
     // @ts-ignore
-    expect(() => cosmiconfig('not_exist_rc_name').loadSync()).toThrow(
+    expect(() => cosmiconfigSync('not_exist_rc_name').load()).toThrow(
       expectedError,
     );
   });
@@ -203,7 +203,7 @@ describe('errors not swallowed when async custom loader throws them', () => {
 
   const explorerOptions = {
     loaders: {
-      '.things': { async: loadThingsAsync },
+      '.things': loadThingsAsync,
     },
   };
 
@@ -227,7 +227,7 @@ describe('errors not swallowed when async custom loader rejects', () => {
 
   const explorerOptions = {
     loaders: {
-      '.things': { async: loadThingsAsync },
+      '.things': loadThingsAsync,
     },
   };
 
@@ -235,27 +235,6 @@ describe('errors not swallowed when async custom loader rejects', () => {
     await expect(
       cosmiconfig('not_exist_rc_name', explorerOptions).load(file),
     ).rejects.toThrow(expectedError);
-  });
-});
-
-describe('errors if only async loader is set but you call sync search', () => {
-  const file = temp.absolutePath('.foorc.things');
-  beforeEach(() => {
-    temp.createFile('.foorc.things', 'one\ntwo\nthree\t\t\n  four\n');
-  });
-
-  const loadThingsAsync = async () => ({ things: true });
-
-  const explorerOptions = {
-    loaders: {
-      '.things': { async: loadThingsAsync },
-    },
-  };
-
-  test('sync', () => {
-    expect(() =>
-      cosmiconfig('not_exist_rc_name', explorerOptions).loadSync(file),
-    ).toThrow('No sync loader specified for extension ".things"');
   });
 });
 
@@ -271,7 +250,7 @@ describe('errors if no loader is set but you call sync load', () => {
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('not_exist_rc_name', explorerOptions).loadSync(file),
+      cosmiconfigSync('not_exist_rc_name', explorerOptions).load(file),
     ).toThrow('No sync loader specified for extension ".things"');
   });
 });

--- a/test/failed-files.test.ts
+++ b/test/failed-files.test.ts
@@ -238,7 +238,7 @@ describe('errors not swallowed when async custom loader rejects', () => {
   });
 });
 
-describe('errors if no loader is set but you call sync load', () => {
+describe('errors if no loader is set for loaded file', () => {
   const file = temp.absolutePath('.foorc.things');
   beforeEach(() => {
     temp.createFile('.foorc.things', 'one\ntwo\nthree\t\t\n  four\n');
@@ -248,9 +248,15 @@ describe('errors if no loader is set but you call sync load', () => {
     loaders: {},
   };
 
+  test('async', async () => {
+    await expect(
+      cosmiconfig('not_exist_rc_name', explorerOptions).load(file),
+    ).rejects.toThrow('No loader specified for extension ".things"');
+  });
+
   test('sync', () => {
     expect(() =>
       cosmiconfigSync('not_exist_rc_name', explorerOptions).load(file),
-    ).toThrow('No sync loader specified for extension ".things"');
+    ).toThrow('No loader specified for extension ".things"');
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,6 +9,7 @@ const createExplorerMock: typeof createExplorer & jest.Mock = createExplorer;
 
 // Mock `createExplorer` because we want to check what it is called with.
 jest.mock('../src/createExplorer');
+jest.mock('../src/createExplorerSync');
 
 const temp = new TempDir();
 

--- a/test/successful-directories.test.ts
+++ b/test/successful-directories.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { TempDir } from './util';
-import { cosmiconfig, defaultLoaders } from '../src';
+import { cosmiconfig, cosmiconfigSync, defaultLoaders } from '../src';
 
 const temp = new TempDir();
 
@@ -64,7 +64,7 @@ describe('finds rc file in third searched dir, with a package.json lacking prop'
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -109,7 +109,7 @@ describe('finds package.json prop in second searched dir', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -160,7 +160,7 @@ describe('finds package.json with nested packageProp in second searched dir', ()
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -205,7 +205,7 @@ describe('finds JS file in first searched dir', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -249,7 +249,7 @@ describe('finds .foorc.js file in first searched dir', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -295,7 +295,7 @@ describe('skips over empty file to find JS file in first searched dir', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -337,7 +337,7 @@ describe('finds package.json in second dir searched, with alternate names', () =
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -381,7 +381,7 @@ describe('finds rc file in third searched dir, skipping packageProp, parsing ext
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -422,7 +422,7 @@ describe('finds package.json file in second searched dir, skipping JS and RC fil
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -468,7 +468,7 @@ describe('finds .foorc.json in second searched dir', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -508,7 +508,7 @@ describe('finds .foorc.yaml in first searched dir', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -549,7 +549,7 @@ describe('finds .foorc.yml in first searched dir', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -605,7 +605,7 @@ describe('adding myfooconfig.js to searchPlaces, finds it in first searched dir'
 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -664,7 +664,7 @@ describe('finds JS file traversing from cwd', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync();
+    const result = cosmiconfigSync('foo', explorerOptions).search();
     checkResult(readFileSpy, result);
   });
 });
@@ -713,7 +713,7 @@ describe('searchPlaces can include subdirectories', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -780,7 +780,7 @@ describe('custom loaders allow non-default file types', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -847,7 +847,7 @@ describe('adding custom loaders allows for default and non-default file types', 
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -901,7 +901,7 @@ describe('defaults loaders can be overridden', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -911,7 +911,11 @@ describe('custom loaders can be async', () => {
 
   let loadThingsSync: any;
   let loadThingsAsync: any;
-  let explorerOptions: any;
+  const baseOptions = {
+    stopDir: temp.absolutePath('.'),
+    searchPlaces: ['.foorc.things'],
+  };
+
   beforeEach(() => {
     temp.createFile(
       'a/b/c/d/e/f/.foorc.things',
@@ -920,14 +924,6 @@ describe('custom loaders can be async', () => {
 
     loadThingsSync = jest.fn(() => ({ things: true }));
     loadThingsAsync = jest.fn(async () => ({ things: true }));
-
-    explorerOptions = {
-      stopDir: temp.absolutePath('.'),
-      searchPlaces: ['.foorc.things'],
-      loaders: {
-        '.things': { sync: loadThingsSync, async: loadThingsAsync },
-      },
-    };
   });
 
   const checkResult = (readFileSpy: any, result: any) => {
@@ -942,6 +938,12 @@ describe('custom loaders can be async', () => {
 
   test('async', async () => {
     const readFileSpy = jest.spyOn(fs, 'readFile');
+    const explorerOptions = {
+      ...baseOptions,
+      loaders: {
+        '.things': loadThingsAsync,
+      },
+    };
 
     const result = await cosmiconfig('foo', explorerOptions).search(startDir);
     expect(loadThingsSync).not.toHaveBeenCalled();
@@ -952,7 +954,14 @@ describe('custom loaders can be async', () => {
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const explorerOptions = {
+      ...baseOptions,
+      loaders: {
+        '.things': loadThingsSync,
+      },
+    };
+
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     expect(loadThingsSync).toHaveBeenCalled();
     expect(loadThingsAsync).not.toHaveBeenCalled();
     checkResult(readFileSpy, result);
@@ -975,7 +984,7 @@ describe('a custom loader entry can include just an async loader', () => {
     stopDir: temp.absolutePath('.'),
     searchPlaces: ['.foorc.things'],
     loaders: {
-      '.things': { async: loadThingsAsync },
+      '.things': loadThingsAsync,
     },
   };
 
@@ -1015,7 +1024,7 @@ describe('a custom loader entry can include only a sync loader and work for both
     stopDir: temp.absolutePath('.'),
     searchPlaces: ['.foorc.things'],
     loaders: {
-      '.things': { sync: loadThingsSync },
+      '.things': loadThingsSync,
     },
   };
 
@@ -1039,7 +1048,7 @@ describe('a custom loader entry can include only a sync loader and work for both
   test('sync', () => {
     const readFileSpy = jest.spyOn(fs, 'readFileSync');
 
-    const result = cosmiconfig('foo', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
     checkResult(readFileSpy, result);
   });
 });
@@ -1059,7 +1068,7 @@ describe('works fine if sync loader returns a Promise from a JS file', () => {
   };
 
   test('sync', async () => {
-    const result = cosmiconfig('bar', explorerOptions).searchSync(startDir);
+    const result = cosmiconfigSync('bar', explorerOptions).search(startDir);
     expect(result).toEqual({
       filepath: temp.absolutePath('a/b/c/d/e/f/bar.config.js'),
       config: expect.any(Promise),

--- a/test/successful-files.test.ts
+++ b/test/successful-files.test.ts
@@ -1,5 +1,5 @@
 import { TempDir } from './util';
-import { cosmiconfig } from '../src';
+import { cosmiconfig, cosmiconfigSync } from '../src';
 
 const temp = new TempDir();
 
@@ -33,7 +33,7 @@ describe('loads defined JSON config path', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('successful-files-tests').loadSync(file);
+    const result = cosmiconfigSync('successful-files-tests').load(file);
     checkResult(result);
   });
 });
@@ -55,7 +55,7 @@ describe('loads defined YAML config path', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('successful-files-tests').loadSync(file);
+    const result = cosmiconfigSync('successful-files-tests').load(file);
     checkResult(result);
   });
 });
@@ -77,7 +77,7 @@ describe('loads defined JS config path', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('successful-files-tests').loadSync(file);
+    const result = cosmiconfigSync('successful-files-tests').load(file);
     checkResult(result);
   });
 });
@@ -100,7 +100,7 @@ describe('loads modularized JS config path', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('successful-files-tests').loadSync(file);
+    const result = cosmiconfigSync('successful-files-tests').load(file);
     checkResult(result);
   });
 });
@@ -122,7 +122,7 @@ describe('loads yaml-like JS config path', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('successful-files-tests').loadSync(file);
+    const result = cosmiconfigSync('successful-files-tests').load(file);
     checkResult(result);
   });
 });
@@ -149,74 +149,71 @@ describe('loads package prop when configPath is package.json', () => {
   };
 
   describe('default package prop', () => {
-    const explorer = cosmiconfig('foo');
     const expectedConfig = { bar: 'baz' };
 
     test('async', async () => {
-      const result = await explorer.load(configPath);
+      const result = await cosmiconfig('foo').load(configPath);
       checkResult(result, expectedConfig);
     });
 
     test('sync', () => {
-      const result = explorer.loadSync(configPath);
+      const result = cosmiconfigSync('foo').load(configPath);
       checkResult(result, expectedConfig);
     });
   });
 
   describe('specified packageProp', () => {
-    const explorer = cosmiconfig('foo', { packageProp: 'otherPackage' });
     const expectedConfig = { please: 'no' };
+    const explorerOptions = { packageProp: 'otherPackage' };
 
     test('async', async () => {
-      const result = await explorer.load(configPath);
+      const result = await cosmiconfig('foo', explorerOptions).load(configPath);
       checkResult(result, expectedConfig);
     });
 
     test('sync', () => {
-      const result = explorer.loadSync(configPath);
+      const result = cosmiconfigSync('foo', explorerOptions).load(configPath);
       checkResult(result, expectedConfig);
     });
   });
 
   describe('nested packageProp', () => {
-    const explorer = cosmiconfig('foo', { packageProp: 'foo.bar' });
     const expectedConfig = 'baz';
+    const explorerOptions = { packageProp: 'foo.bar' };
 
     test('async', async () => {
-      const result = await explorer.load(configPath);
+      const result = await cosmiconfig('foo', explorerOptions).load(configPath);
       checkResult(result, expectedConfig);
     });
 
     test('sync', () => {
-      const result = explorer.loadSync(configPath);
+      const result = cosmiconfigSync('foo', explorerOptions).load(configPath);
       checkResult(result, expectedConfig);
     });
   });
 
   describe('inaccurate packageProp returns undefined, does not error', () => {
-    const explorer = cosmiconfig('foo', { packageProp: 'otherrrPackage' });
-
+    const options = { packageProp: 'otherrrPackage' };
     test('async', async () => {
-      const result = await explorer.load(configPath);
+      const result = await cosmiconfig('foo', options).load(configPath);
       expect(result).toBeNull();
     });
 
     test('sync', () => {
-      const result = explorer.loadSync(configPath);
+      const result = cosmiconfigSync('foo', options).load(configPath);
       expect(result).toBeNull();
     });
   });
 
   describe('inaccurate nested packageProp returns undefined, does not error', () => {
-    const explorer = cosmiconfig('foo', { packageProp: 'foo.baz' });
-
+    const options = { packageProp: 'foo.baz' };
     test('async', async () => {
-      const result = await explorer.load(configPath);
+      const result = await cosmiconfig('foo', options).load(configPath);
       expect(result).toBeNull();
     });
 
     test('sync', () => {
-      const result = explorer.loadSync(configPath);
+      const result = cosmiconfigSync('foo', options).load(configPath);
       expect(result).toBeNull();
     });
   });
@@ -244,9 +241,9 @@ describe('runs transform', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('successful-files-tests', {
+    const result = cosmiconfigSync('successful-files-tests', {
       transform,
-    }).loadSync(configPath);
+    }).load(configPath);
     checkResult(result);
   });
 });
@@ -270,7 +267,7 @@ describe('does not swallow transform errors', () => {
 
   test('sync', () => {
     expect(() =>
-      cosmiconfig('successful-files-tests', { transform }).loadSync(configPath),
+      cosmiconfigSync('successful-files-tests', { transform }).load(configPath),
     ).toThrow(expectedError);
   });
 });
@@ -292,7 +289,7 @@ describe('loads defined JSON file with no extension', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('successful-files-tests').loadSync(file);
+    const result = cosmiconfigSync('successful-files-tests').load(file);
     checkResult(result);
   });
 });
@@ -314,7 +311,7 @@ describe('loads defined YAML file with no extension', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('successful-files-tests').loadSync(file);
+    const result = cosmiconfigSync('successful-files-tests').load(file);
     checkResult(result);
   });
 });
@@ -322,16 +319,10 @@ describe('loads defined YAML file with no extension', () => {
 describe('custom loaders can be async', () => {
   let loadThingsSync: any;
   let loadThingsAsync: any;
-  let explorerOptions: any;
   beforeEach(() => {
     temp.createFile('.foorc.things', 'one\ntwo\nthree\t\t\n  four\n');
     loadThingsSync = jest.fn(() => ({ things: true }));
     loadThingsAsync = jest.fn(async () => ({ things: true }));
-    explorerOptions = {
-      loaders: {
-        '.things': { sync: loadThingsSync, async: loadThingsAsync },
-      },
-    };
   });
 
   const file = temp.absolutePath('.foorc.things');
@@ -341,12 +332,24 @@ describe('custom loaders can be async', () => {
   };
 
   test('async', async () => {
+    const explorerOptions = {
+      loaders: {
+        '.things': loadThingsAsync,
+      },
+    };
+
     const result = await cosmiconfig('foo', explorerOptions).load(file);
     checkResult(result);
   });
 
   test('sync', () => {
-    const result = cosmiconfig('foo', explorerOptions).loadSync(file);
+    const explorerOptions = {
+      loaders: {
+        '.things': loadThingsSync,
+      },
+    };
+
+    const result = cosmiconfigSync('foo', explorerOptions).load(file);
     checkResult(result);
   });
 });
@@ -360,7 +363,7 @@ describe('a custom loader entry can include just an async loader', () => {
 
   const explorerOptions = {
     loaders: {
-      '.things': { async: loadThingsAsync },
+      '.things': loadThingsAsync,
     },
   };
 
@@ -387,7 +390,7 @@ describe('a custom loader entry can include only a sync loader and work for both
 
   const explorerOptions = {
     loaders: {
-      '.things': { sync: loadThingsSync },
+      '.things': loadThingsSync,
     },
   };
 
@@ -403,7 +406,7 @@ describe('a custom loader entry can include only a sync loader and work for both
   });
 
   test('sync', () => {
-    const result = cosmiconfig('foo', explorerOptions).loadSync(file);
+    const result = cosmiconfigSync('foo', explorerOptions).load(file);
     checkResult(result);
   });
 });
@@ -423,7 +426,7 @@ describe('works fine if sync loader returns a Promise from a JS file', () => {
   };
 
   test('sync', async () => {
-    const result = cosmiconfig('foo', explorerOptions).loadSync(file);
+    const result = cosmiconfigSync('foo', explorerOptions).load(file);
     expect(result).toEqual({
       filepath: file,
       config: expect.any(Promise),
@@ -463,7 +466,7 @@ describe('loads defined JS config relative path', () => {
   });
 
   test('sync', () => {
-    const result = cosmiconfig('successful-files-tests').loadSync(relativeFile);
+    const result = cosmiconfigSync('successful-files-tests').load(relativeFile);
     checkResult(result);
   });
 });


### PR DESCRIPTION
This PR separates the `async` and `sync` apis from each other as described in #209.

```js
import { cosmiconfig, cosmiconfigSync } from 'cosmiconfig';

const explorer = cosmiconfig({
	loaders: {
		'.js': async () => {},
		'.ts': () => {}, // can be sync
	},
	transform: async (config) => config,
	// transform: (config) => config, // can also be sync
});

await explorer.search();
await explorer.load();

const explorerSync = cosmiconfigSync({
	loaders: {
		'.js': () => {},
		'.ts': async () => {}, // can not be async, invalid
	},
	transform: (config) => config,
	// transform: async (config) => config, // can not be async, invalid
});

explorerSync.search();
explorerSync.load();
```

I think the readme could be updated further to be more condensed and clear by adding a note about the `cosmiconfigSync` separation and removing all references to what was previously `loadSync` and `searchSync`.