### PR TITLE
move @types dependency to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     ]
   },
   "dependencies": {
-    "@types/parse-json": "^4.0.0",
     "import-fresh": "^3.1.0",
     "parse-json": "^5.0.0",
     "path-type": "^4.0.0",
@@ -122,6 +121,7 @@
     "@babel/preset-typescript": "^7.6.0",
     "@types/jest": "^24.0.19",
     "@types/node": "^12.11.5",
+    "@types/parse-json": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",
     "cross-env": "^6.0.3",


### PR DESCRIPTION
Hi, looks like the users of cosmiconfig had to download `@types/parse-json` when adding cosmiconfig to their project. From what I saw this dependency is only needed when working on cosmiconfig directly. Therefore, it makes sense to keep it in devDependencies.