### PR TITLE
Upgrade remark-toc to fix TOC link bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you are still using v5, those v5 docs are available [in the `5.x.x` tagged co
 - [Usage](#usage)
 - [Result](#result)
 - [Asynchronous API](#asynchronous-api)
-  - [cosmiconfig()](#cosmiconfig)
+  - [cosmiconfig()](#cosmiconfig-1)
   - [explorer.search()](#explorersearch)
   - [explorer.load()](#explorerload)
   - [explorer.clearLoadCache()](#explorerclearloadcache)

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "make-dir": "^3.0.0",
     "parent-module": "^2.0.0",
     "prettier": "^1.18.2",
-    "remark-preset-davidtheclark": "^0.10.0",
+    "remark-preset-davidtheclark": "^0.12.0",
     "typescript": "^3.6.4"
   },
   "engines": {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-extraneous-class,@typescript-eslint/explicit-member-accessibility */
+/* eslint-disable @typescript-eslint/no-extraneous-class,@typescript-eslint/explicit-member-accessibility,@typescript-eslint/no-empty-function */
 import os from 'os';
 import { TempDir } from './util';
 import {


### PR DESCRIPTION
Replaces https://github.com/davidtheclark/cosmiconfig/pull/225. Thanks for pointing that out, @KSXGitHub.

The change to ignore `@typescript-eslint/no-empty-function` in the test file must be due to a non-major change in typescript-eslint that adjusted that rule — a negative consequence of not committing the lockfile.