### PR TITLE
fix packageProp type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export type TransformSync = (
 ) => CosmiconfigResult;
 
 interface OptionsBase {
-  packageProp?: string;
+  packageProp?: string | Array<string>;
   searchPlaces?: Array<string>;
   ignoreEmptySearchPlaces?: boolean;
   stopDir?: string;


### PR DESCRIPTION
Hi, I found an inconsistency since in the [`readme`](https://github.com/davidtheclark/cosmiconfig#packageprop) it is noted that it can be either a string or an array of string. I've checked and both work as expected, but typescript is complaining when I pass an array. This should fix this.