### PR TITLE
feat(loaders): adds the ability to use merge (`<<`) syntax

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -38,7 +38,7 @@ const loadYaml: LoaderSync = function loadYaml(filepath, content) {
   }
 
   try {
-    const result = yaml.parse(content, { prettyErrors: true });
+    const result = yaml.parse(content, { prettyErrors: true, merge: true });
     return result;
   } catch (error) {
     error.message = `YAML Error in ${filepath}:\n${error.message}`;


### PR DESCRIPTION
The `yaml` package has turned `merge` syntax off in recent versions. This PR adds `merge` syntax back in.