### PR TITLE
@types/parse-json should be a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     ]
   },
   "dependencies": {
-    "@types/parse-json": "^4.0.0",
     "import-fresh": "^3.2.1",
     "parse-json": "^5.0.0",
     "path-type": "^4.0.0",
@@ -119,6 +118,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@types/jest": "^26.0.4",
     "@types/node": "^14.0.22",
+    "@types/parse-json": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",
     "cross-env": "^7.0.2",


### PR DESCRIPTION
Your end users don't require the type definition for parse-json so you should make it a dev-dependency