### PR TITLE
Do not crash if there is a directory named after a search place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- Fixed: If there was a directory that had the same name as a search place (e.g. "package.json"), we would try to read it as a file, which would cause an exception.
+
 ## 7.0.0
 
 - **Breaking change:** Add `${moduleName}rc.cjs` and `${moduleName}.config.cjs` to the default `searchPlaces`, to support users of `"type": "module"` in recent versions of Node.

--- a/src/readFile.ts
+++ b/src/readFile.ts
@@ -31,7 +31,10 @@ async function readFile(
 
     return content;
   } catch (error) {
-    if (throwNotFound === false && error.code === 'ENOENT') {
+    if (
+      throwNotFound === false &&
+      (error.code === 'ENOENT' || error.code === 'EISDIR')
+    ) {
       return null;
     }
 
@@ -47,7 +50,10 @@ function readFileSync(filepath: string, options: Options = {}): string | null {
 
     return content;
   } catch (error) {
-    if (throwNotFound === false && error.code === 'ENOENT') {
+    if (
+      throwNotFound === false &&
+      (error.code === 'ENOENT' || error.code === 'EISDIR')
+    ) {
       return null;
     }
 

--- a/src/readFile.ts
+++ b/src/readFile.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 
 async function fsReadFileAsync(
   pathname: string,
-  encoding: string,
+  encoding: BufferEncoding,
 ): Promise<string> {
   return new Promise((resolve, reject): void => {
     fs.readFile(pathname, encoding, (error, contents): void => {

--- a/test/successful-directories.test.ts
+++ b/test/successful-directories.test.ts
@@ -780,6 +780,52 @@ describe('searchPlaces can include subdirectories', () => {
   });
 });
 
+describe('directories are not treated as files', () => {
+  beforeEach(() => {
+    temp.createFile('a/.foorc.json', '{ "found": true }');
+    temp.createDir('a/b/package.json/c');
+  });
+
+  const startDir = temp.absolutePath('a/b/package.json/c');
+  const explorerOptions = {
+    stopDir: temp.absolutePath('.'),
+    searchPlaces: ['package.json', '.foorc.json'],
+  };
+
+  const checkResult = (readFileSpy: any, result: any) => {
+    const filesChecked = temp.getSpyPathCalls(readFileSpy);
+    expect(filesChecked).toEqual([
+      'a/b/package.json/c/package.json',
+      'a/b/package.json/c/.foorc.json',
+      'a/b/package.json/package.json',
+      'a/b/package.json/.foorc.json',
+      'a/b/package.json',
+      'a/b/.foorc.json',
+      'a/package.json',
+      'a/.foorc.json',
+    ]);
+
+    expect(result).toEqual({
+      config: { found: true },
+      filepath: temp.absolutePath('a/.foorc.json'),
+    });
+  };
+
+  test('async', async () => {
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+
+    const result = await cosmiconfig('foo', explorerOptions).search(startDir);
+    checkResult(readFileSpy, result);
+  });
+
+  test('sync', () => {
+    const readFileSpy = jest.spyOn(fs, 'readFileSync');
+
+    const result = cosmiconfigSync('foo', explorerOptions).search(startDir);
+    checkResult(readFileSpy, result);
+  });
+});
+
 describe('custom loaders allow non-default file types', () => {
   const loadThings = (filepath: any, content: any) => {
     return {

--- a/test/successful-directories.test.ts
+++ b/test/successful-directories.test.ts
@@ -780,7 +780,7 @@ describe('searchPlaces can include subdirectories', () => {
   });
 });
 
-describe('directories are not treated as files', () => {
+describe('directories with the same name as a search place are not treated as files', () => {
   beforeEach(() => {
     temp.createFile('a/.foorc.json', '{ "found": true }');
     temp.createDir('a/b/package.json/c');


### PR DESCRIPTION
Recently fixed a very similar bug in eslint 😆 

refs https://github.com/rollup/plugins/pull/981