### PR TITLE
Replace reference for typescript loader suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ If you want to load files that are not handled by the loader functions Cosmiconf
 
 **Third-party loaders:**
 
-- [@endemolshinegroup/cosmiconfig-typescript-loader](https://github.com/EndemolShineGroup/cosmiconfig-typescript-loader)
+- [cosmiconfig-typescript-loader](https://github.com/codex-/cosmiconfig-typescript-loader)
 
 **Use cases for custom loader function:**
 


### PR DESCRIPTION
The currently suggested package for handling the loading of TypeScript config files with cosmiconfig is no longer maintained:

### `@endemolshinegroup/cosmiconfig-typescript-loader`

As of recently, `endemolshinegroup` appears to no longer be maintaining the original package. I can only assume this is to do with the fact that Endemol Shine Group [was purchased and absorbed by another business](https://en.wikipedia.org/wiki/Endemol_Shine_Group#Sale_to_Banijay). This discontinuation of development efforts towards the original package left any open issues and pull requests unresolved.

With now over a year of no development:

![image](https://user-images.githubusercontent.com/8297838/144040663-f8e7783b-ee5a-4593-a961-be585016803a.png)

### [`cosmiconfig-typescript-loader`](https://github.com/Codex-/cosmiconfig-typescript-loader)

I've rewritten this loader and resolved any of the issues I could find outstanding from the original loader:

- [`#134`](https://github.com/EndemolShineGroup/cosmiconfig-typescript-loader/issues/134): "Doesn't work with Cosmiconfig sync API"
- [`#147`](https://github.com/EndemolShineGroup/cosmiconfig-typescript-loader/issues/147): "doesn't provide typescript, requested by ts-node"
- [`#155`](https://github.com/EndemolShineGroup/cosmiconfig-typescript-loader/issues/155): "Misleading TypeScriptCompileError when user's tsconfig.json "module" is set to "es2015""

Please consider this documentation change to suggest using my replacement package where I can resolve any new issues that arise 😅, or at the very least, remove the no longer maintained package to help alleviate some potential headaches.