### PR TITLE
Upgrade `yaml` to `2.0.1` to remove deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "import-fresh": "^3.2.1",
     "parse-json": "^5.0.0",
     "path-type": "^4.0.0",
-    "yaml": "^1.10.0"
+    "yaml": "^2.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.4",

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -26,7 +26,9 @@ const loadJson: LoaderSync = function loadJson(filepath, content) {
     const result = parseJson(content);
     return result;
   } catch (error) {
-    error.message = `JSON Error in ${filepath}:\n${error.message}`;
+    (error as Error).message = `JSON Error in ${filepath}:\n${
+      (error as Error).message
+    }`;
     throw error;
   }
 };
@@ -41,7 +43,9 @@ const loadYaml: LoaderSync = function loadYaml(filepath, content) {
     const result = yaml.parse(content, { prettyErrors: true });
     return result;
   } catch (error) {
-    error.message = `YAML Error in ${filepath}:\n${error.message}`;
+    (error as Error).message = `YAML Error in ${filepath}:\n${
+      (error as Error).message
+    }`;
     throw error;
   }
 };


### PR DESCRIPTION
## Motivation

To resolve #266

## Approach

- Upgraded yaml dependency
- Fixed a small typescript error in loader.ts