### PR TITLE
Fix js-yaml, type imports

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,1 +1,0 @@
-declare module 'yaml';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,10 @@
       "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
-        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "path-type": "^4.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.10.4",
@@ -21,7 +20,9 @@
         "@babel/preset-env": "^7.10.4",
         "@babel/preset-typescript": "^7.10.4",
         "@types/jest": "^26.0.4",
+        "@types/js-yaml": "^4.0.5",
         "@types/node": "^14.0.22",
+        "@types/parse-json": "^4.0.0",
         "@typescript-eslint/eslint-plugin": "^3.6.0",
         "@typescript-eslint/parser": "^3.6.0",
         "cross-env": "^7.0.2",
@@ -43,7 +44,7 @@
         "typescript": "^3.9.6"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2818,6 +2819,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2866,7 +2873,8 @@
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.6.1",
@@ -13988,6 +13996,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -16142,6 +16151,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -16190,7 +16205,8 @@
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
     },
     "@types/prettier": {
       "version": "2.6.1",
@@ -20675,7 +20691,8 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
         "argparse": "^2.0.1"
@@ -24576,7 +24593,8 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -107,9 +107,9 @@
   },
   "dependencies": {
     "import-fresh": "^3.2.1",
+    "js-yaml": "^4.1.0",
     "parse-json": "^5.0.0",
-    "path-type": "^4.0.0",
-    "js-yaml": "^4.1.0"
+    "path-type": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.4",
@@ -117,6 +117,7 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
     "@types/jest": "^26.0.4",
+    "@types/js-yaml": "^4.0.5",
     "@types/node": "^14.0.22",
     "@types/parse-json": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^3.6.0",

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -1,12 +1,9 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 
-import parseJsonType from 'parse-json';
-import yamlType from 'yaml';
-import importFreshType from 'import-fresh';
 import { LoaderSync } from './index';
 import { LoadersSync } from './types';
 
-let importFresh: typeof importFreshType;
+let importFresh: typeof import('import-fresh');
 const loadJs: LoaderSync = function loadJs(filepath) {
   if (importFresh === undefined) {
     importFresh = require('import-fresh');
@@ -16,7 +13,7 @@ const loadJs: LoaderSync = function loadJs(filepath) {
   return result;
 };
 
-let parseJson: typeof parseJsonType;
+let parseJson: typeof import('parse-json');
 const loadJson: LoaderSync = function loadJson(filepath, content) {
   if (parseJson === undefined) {
     parseJson = require('parse-json');
@@ -31,14 +28,14 @@ const loadJson: LoaderSync = function loadJson(filepath, content) {
   }
 };
 
-let yaml: typeof yamlType;
+let yaml: typeof import('js-yaml');
 const loadYaml: LoaderSync = function loadYaml(filepath, content) {
   if (yaml === undefined) {
-    yaml = require('yaml');
+    yaml = require('js-yaml');
   }
 
   try {
-    const result = yaml.parse(content, { prettyErrors: true });
+    const result = yaml.load(content);
     return result;
   } catch (error) {
     error.message = `YAML Error in ${filepath}:\n${error.message}`;

--- a/test/failed-directories.test.ts
+++ b/test/failed-directories.test.ts
@@ -133,7 +133,7 @@ describe('throws error for invalid YAML in rc file', () => {
 
   const expectedError = `YAML Error in ${temp.absolutePath(
     'a/b/.foorc',
-  )}:\nNested mappings are not allowed in compact mappings at line 1, column 8:`;
+  )}:\nbad indentation of a mapping entry (1:12)`;
 
   test('async', async () => {
     await expect(
@@ -260,7 +260,7 @@ describe('throws error for invalid YAML in .foorc.yml', () => {
 
   const expectedError = `YAML Error in ${temp.absolutePath(
     'a/b/c/d/e/f/.foorc.yml',
-  )}:\nNested mappings are not allowed in compact mappings at line 1, column 8:`;
+  )}:\nbad indentation of a mapping entry (1:13)`;
 
   test('async', async () => {
     await expect(

--- a/test/failed-files.test.ts
+++ b/test/failed-files.test.ts
@@ -56,7 +56,7 @@ describe('throws error if defined YAML file has syntax error', () => {
   });
 
   const file = temp.absolutePath('foo-invalid.yaml');
-  const expectedError = `YAML Error in ${file}:\nNested mappings are not allowed in compact mappings at line 1, column 6:`;
+  const expectedError = `YAML Error in ${file}:\nbad indentation of a mapping entry (1:10)`;
 
   test('async', async () => {
     await expect(cosmiconfig('failed-files-tests').load(file)).rejects.toThrow(


### PR DESCRIPTION
This fixes the use of `js-yaml` by `npm i`-ing to fix the lock, adding the right types package, and then calling the right function.

I also made a minor loader fix; the imports at the top to get the type for the lazily-loaded modules will actually cause an import to occur immediately. I can revert this part if you'd like.

There are some other type errors to do with the thrown errors, but they don't appear when running `tsc` because the version of TypeScript this repo uses is super out of date (far past what DefinitelyTyped supports, so I would strongly suggest upgrading).