### PR TITLE
Add support for `*.mjs`, `*.config.mjs`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ function cosmiconfigSync(moduleName: string, options: OptionsSync = {}) {
 // do not allow mutation of default loaders. Make sure it is set inside options
 const defaultLoaders = Object.freeze({
   '.cjs': loaders.loadJs,
+  '.mjs': loaders.loadJs,
   '.js': loaders.loadJs,
   '.json': loaders.loadJson,
   '.yaml': loaders.loadYaml,
@@ -116,8 +117,10 @@ function normalizeOptions(
       `.${moduleName}rc.yml`,
       `.${moduleName}rc.js`,
       `.${moduleName}rc.cjs`,
+      `.${moduleName}rc.mjs`,
       `${moduleName}.config.js`,
       `${moduleName}.config.cjs`,
+      `${moduleName}.config.mjs`,
     ],
     ignoreEmptySearchPlaces: true,
     stopDir: os.homedir(),


### PR DESCRIPTION
Hello there!

It would be useful to support `*.mjs`, what do you people think?

It originated from here:
https://github.com/mdx-js/eslint-mdx/issues/436#issuecomment-1296084347

Cheers