### PR TITLE
Fix the cosmiconfig() link in the cosmiconfigSync section

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ const explorerSync = cosmiconfigSync(moduleName[, cosmiconfigOptions])
 
 Creates a *synchronous* cosmiconfig instance ("explorerSync") configured according to the arguments, and initializes its caches.
 
-See [`cosmiconfig()`].
+See [`cosmiconfig()`](#cosmiconfig-1).
 
 ### explorerSync.search()
 


### PR DESCRIPTION
This link is broken now because it leads to the beginning of the README.